### PR TITLE
Improve readability perfect minimal hash algorithm

### DIFF
--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -1,0 +1,87 @@
+/*
+ * Frozen
+ * Copyright 2016 QuarksLab
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_BASIC_TYPES_H
+#define FROZEN_LETITGO_BASIC_TYPES_H
+
+#include <array>
+
+namespace frozen {
+
+namespace bits {
+
+template <class T, std::size_t N>
+class cvector {
+  T data [N] = {}; // zero-initialization for scalar type T, default-initialized otherwise
+  std::size_t dsize = 0;
+
+public:
+  // Container typdefs
+  using value_type = T;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using pointer = value_type *;
+  using const_pointer = const value_type *;
+  using iterator = pointer;
+  using const_iterator = const_pointer;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+
+  // Iterators
+  constexpr iterator begin() noexcept { return data; }
+  constexpr iterator end() noexcept { return data + dsize; }
+
+  // Capacity
+  constexpr size_type size() const { return dsize; }
+
+  // Element access
+  constexpr       reference operator[](std::size_t index) { return data[index]; }
+  constexpr const_reference operator[](std::size_t index) const { return data[index]; }
+
+  constexpr       reference back() { return data[dsize - 1]; }
+  constexpr const_reference back() const { return data[dsize - 1]; }
+
+  // Modifiers
+  constexpr void push_back(const T & a) { data[dsize++] = a; }
+  constexpr void push_back(T && a) { data[dsize++] = std::move(a); }
+  constexpr void pop_back() { --dsize; }
+
+  constexpr void clear() { dsize = 0; }
+
+  // Convert to std::array
+  constexpr std::array<T, N> to_array() {
+    std::array<T, N> a{};
+    auto * ta = &std::get<0>(a);
+
+    for(std::size_t i = 0; i < N; i++)
+        ta[i] = data[i];
+
+    return a;
+  }
+};
+
+
+} // namespace bits
+
+} // namespace frozen
+
+#endif

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -25,6 +25,7 @@
 #define FROZEN_LETITGO_PMH_H
 
 #include <frozen/bits/algorithms.h>
+#include <frozen/bits/basic_types.h>
 
 #include <array>
 #include <tuple>
@@ -33,22 +34,25 @@ namespace frozen {
 
 namespace bits {
 
-template <class T, size_t N>
-constexpr auto bucket_size(std::array<T, N> const &bucket) {
-  std::size_t i = 0;
-  auto ptr = &std::get<0>(bucket);
-  while (i < N && ptr[i])
-    ++i;
-  return i;
-}
+template <size_t N>
+using bucket = cvector<std::size_t, N>;
 
 struct bucket_size_compare {
-  template <class T, size_t N>
-  auto constexpr operator()(std::array<T, N> const &b0,
-                            std::array<T, N> const &b1) const {
-    return bucket_size(b0) > bucket_size(b1);
+  template <size_t N>
+  auto constexpr operator()(bucket<N> const &b0,
+                            bucket<N> const &b1) const {
+    return b0.size() > b1.size();
   }
 };
+
+template<class T, size_t N>
+constexpr bool all_different_from(cvector<T, N> & data, T & a) {
+  for (std::size_t i = 0; i < data.size(); ++i)
+    if (data[i] == a)
+      return false;
+
+  return true;
+}
 
 template <class Item, std::size_t N, std::size_t M, class Hash, class Key>
 std::tuple<
@@ -58,101 +62,72 @@ std::tuple<
                                                            Hash const &hash,
                                                            Key const &key) {
   // Step 1: Place all of the keys into buckets
-  std::array<std::array<std::size_t, M>, M> tbuckets{{{{0}}}};
-  std::array<uint64_t, M> values{{0}};
-  std::array<int64_t, M> G{{0}};
+  cvector<bucket<M>, M> buckets;
+  cvector<uint64_t, M> values;
+  cvector<int64_t, M> G;
 
-  auto *g = &std::get<0>(G);
-  auto *v = &std::get<0>(values);
-  auto *tb = &std::get<0>(tbuckets);
   auto *it = &std::get<0>(items);
 
-  for (std::size_t i = 0; i < N; ++i) {
-    auto const h = hash(key(it[i])) % M;
-    std::size_t j = 0;
-    auto *tbh = &std::get<0>(tb[h]);
-    while (tbh[j])
-      ++j;
-    tbh[j] = 1 + i;
-  }
-
-  auto buckets = bits::quicksort(tbuckets, bucket_size_compare{});
+  for (std::size_t i = 0; i < N; ++i)
+    buckets[hash(key(it[i])) % M].push_back(1 + i);
 
   // Step 2: Sort the buckets and process the ones with the most items first.
+  bits::quicksort(buckets.begin(), buckets.begin() + M - 1, bucket_size_compare{});
+
   std::size_t b = 0;
   for (; b < M; ++b) {
-    auto &bucket = (&std::get<0>(buckets))[b];
-    auto const bsize = bucket_size(bucket);
+    auto &bucket = buckets[b];
+    auto const bsize = bucket.size();
     if (bsize <= 1)
       break;
-
-    auto *bt = &std::get<0>(bucket);
 
     // Repeatedly try different values of d until we find a hash function
     // that places all items in the bucket into free slots
     std::size_t d = 1;
-    std::size_t item = 0;
-    std::size_t slots[M] = {0};
+    cvector<std::size_t, M> slots;
 
-    while (item < bsize) {
-      auto slot = hash(key(it[bt[item] - 1]), d) % M;
-      if (v[slot] != 0) {
-        d += 1;
-        for (std::size_t j = 0; j < item; ++j)
-          slots[j] = 0;
-        item = 0;
-        continue;
-      }
-      bool all_different = true;
-      for (std::size_t k = 0; k < item; ++k) {
-        if (slots[k] == slot) {
-          all_different = false;
-          break;
-        }
-      }
-      if (!all_different) {
-        d += 1;
-        for (std::size_t j = 0; j < item; ++j)
-          slots[j] = 0;
-        item = 0;
+    while (slots.size() < bsize) {
+      auto slot = hash(key(it[bucket[slots.size()] - 1]), d) % M;
+
+      if (values[slot] != 0 || !all_different_from(slots, slot)) {
+        slots.clear();
+        d++;
         continue;
       }
 
-      slots[item] = slot;
-      item += 1;
+      slots.push_back(slot);
     }
 
-    g[hash(key(it[bt[0] - 1])) % M] = d;
+    G[hash(key(it[bucket[0] - 1])) % M] = d;
     for (std::size_t i = 0; i < bsize; ++i)
-      v[slots[i]] = bt[i];
+      values[slots[i]] = bucket[i];
   }
 
   // Only buckets with 1 item remain. Process them more quickly by directly
   // placing them into a free slot. Use a negative value of d to indicate
   // this.
-  int64_t freelist[M] = {0};
-  std::size_t freelist_size = 0;
+  cvector<int64_t, M> freelist;
 
   for (std::size_t i = 0; i < M; ++i)
-    if (v[i] == 0)
-      freelist[freelist_size++] = i;
+    if (values[i] == 0)
+      freelist.push_back(i);
 
   for (std::size_t i = b; i < M; ++i) {
-    auto &bucket = (&std::get<0>(buckets))[i];
-    if (bucket_size(bucket) == 0)
+    auto &bucket = buckets[i];
+    if (bucket.size() == 0)
       break;
-    auto *bt = &std::get<0>(bucket);
-    auto slot = freelist[--freelist_size];
+    auto slot = freelist.back();
+    freelist.pop_back();
     // We subtract one to ensure it's negative even if the zeroeth slot was
     // used.
-    g[hash(key(it[bt[0] - 1])) % M] = -slot - 1;
-    v[slot] = bt[0];
+    G[hash(key(it[bucket[0] - 1])) % M] = -slot - 1;
+    values[slot] = bucket[0];
   }
   for (std::size_t i = 0; i < M; ++i)
-    if (v[i])
-      v[i] -= 1;
+    if (values[i])
+      values[i]--;
 
-  return {items, G, values};
+  return {items, G.to_array(), values.to_array()};
 }
 
 } // namespace bits

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 SRCS=test_main.cpp test_set.cpp test_map.cpp test_unordered_set.cpp test_unordered_str_set.cpp test_unordered_map.cpp test_unordered_map_str.cpp
 
 TARGET=test_main
-CXXFLAGS=-O3 -g -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow
+CXXFLAGS=-O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow
 CPPFLAGS=-I../include
 
 all:$(TARGET)
@@ -25,18 +25,23 @@ test_set.o: test_set.cpp ../include/frozen/set.h \
 test_unordered_map.o: test_unordered_map.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
-  ../include/frozen/bits/algorithms.h catch.hpp
+  ../include/frozen/bits/algorithms.h \
+  ../include/frozen/bits/basic_types.h \
+  catch.hpp
 test_unordered_map_str.o: test_unordered_map_str.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
-  ../include/frozen/bits/algorithms.h ../include/frozen/string.h \
+  ../include/frozen/bits/algorithms.h \
+  ../include/frozen/bits/basic_types.h ../include/frozen/string.h \
   catch.hpp
 test_unordered_set.o: test_unordered_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
-  ../include/frozen/bits/algorithms.h ../include/frozen/bits/elsa.h \
+  ../include/frozen/bits/algorithms.h \
+  ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   catch.hpp
 test_unordered_str_set.o: test_unordered_str_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
-  ../include/frozen/bits/algorithms.h ../include/frozen/bits/elsa.h \
+  ../include/frozen/bits/algorithms.h \
+  ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   ../include/frozen/string.h \
   catch.hpp


### PR DESCRIPTION
Refactor `make_array_of_items` to improve readability

- Introduce a new `constexpr vector` type to ease manipulating arrays.
- Change `partition` and `quicksort` algorithms to take iterators instead of array and indices
- Remove unused `sort` algorithm