### PR TITLE
Several changes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/test_main
 tests/*.o
+*.*~

--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -91,6 +91,12 @@ constexpr void cswap(T &a, T &b) {
   b = tmp;
 }
 
+template <class T, class U>
+constexpr void cswap(std::pair<T, U> & a, std::pair<T, U> & b) {
+  cswap(a.first, b.first);
+  cswap(a.second, b.second);
+}
+
 template <class... Tys, std::size_t... Is> 
 constexpr void cswap(std::tuple<Tys...> &a, std::tuple<Tys...> &b, std::index_sequence<Is...>) {
   using swallow = int[];

--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -24,8 +24,10 @@
 #define FROZEN_LETITGO_ALGORITHMS_H
 
 #include <array>
-#include <tuple>
 #include <limits>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace frozen {
 
@@ -52,6 +54,21 @@ constexpr std::array<T, N>
 make_unordered_array(std::initializer_list<T> const values) {
   auto iter = values.begin();
   return make_unordered_array<T, N>(iter, std::make_index_sequence<N>{});
+}
+
+// This is std::experimental::to_array
+// http://en.cppreference.com/w/cpp/experimental/to_array
+template <class T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N>
+    to_array_impl(T (&a)[N], std::index_sequence<I...>)
+{
+  return { {a[I]...} };
+}
+
+template <class T, std::size_t N>
+constexpr auto to_array(T (&a)[N]) -> std::array<std::remove_cv_t<T>, N>
+{
+  return to_array_impl(a, std::make_index_sequence<N>{});
 }
 
 template <typename Iter, typename Compare>

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -71,7 +71,7 @@ struct pmh_tables {
   }
 };
 
-template <class Item, std::size_t N, std::size_t M, class Hash, class Key>
+template <std::size_t M, class Item, std::size_t N, class Hash, class Key>
 pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
                                                                items,
                                                            Hash const &hash,

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -25,7 +25,6 @@
 
 #include <array>
 #include <stdexcept>
-#include <tuple>
 #include <utility>
 
 #include "bits/algorithms.h"
@@ -43,19 +42,19 @@ public:
       : comparator_(comparator) {}
 
   template <class Key, class Value>
-  constexpr int operator()(std::tuple<Key, Value> const &self,
-                           std::tuple<Key, Value> const &other) const {
+  constexpr int operator()(std::pair<Key, Value> const &self,
+                           std::pair<Key, Value> const &other) const {
     return comparator_(std::get<0>(self), std::get<0>(other));
   }
 
   template <class Key, class Value>
   constexpr int operator()(Key const &self_key,
-                           std::tuple<Key, Value> const &other) const {
+                           std::pair<Key, Value> const &other) const {
     return comparator_(self_key, std::get<0>(other));
   }
 
   template <class Key, class Value>
-  constexpr int operator()(std::tuple<Key, Value> const &self,
+  constexpr int operator()(std::pair<Key, Value> const &self,
                            Key const &other_key) const {
     return comparator_(std::get<0>(self), other_key);
   }
@@ -69,7 +68,7 @@ public:
 
 template <class Key, class Value, std::size_t N, class Compare = std::less<Key>>
 class map {
-  using container_type = std::array<std::tuple<Key, Value>, N>;
+  using container_type = std::array<std::pair<Key, Value>, N>;
   impl::CompareKey<Compare> compare_;
   container_type keys_;
 
@@ -174,7 +173,7 @@ public:
 template <class Key, class Value, class Compare>
 class map<Key, Value, 0, Compare> {
   using container_type =
-      std::array<std::tuple<Key, Value>, 1>; // just for the type definitions
+      std::array<std::pair<Key, Value>, 1>; // just for the type definitions
   impl::CompareKey<Compare> compare_;
 
 public:
@@ -243,7 +242,7 @@ public:
 };
 
 template <typename T, typename U, std::size_t N>
-constexpr auto make_map(std::tuple<T, U> const (&items)[N]) {
+constexpr auto make_map(std::pair<T, U> const (&items)[N]) {
   return map<T, U, N>{bits::to_array(items)};
 }
 

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -26,6 +26,7 @@
 #include <array>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
 
 #include "bits/algorithms.h"
 
@@ -91,10 +92,14 @@ public:
 
 public:
   /* constructors */
+  constexpr map(container_type items, Compare const &compare)
+      : compare_{compare}
+      , keys_{bits::quicksort(items, compare_)} {}
+  explicit constexpr map(container_type items)
+      : map{items, Compare{}} {}
+
   constexpr map(std::initializer_list<value_type> items, Compare const &compare)
-      : compare_{compare}, keys_{bits::quicksort(
-                               bits::make_unordered_array<value_type, N>(items),
-                               compare_)} {}
+      : map(bits::make_unordered_array<value_type, N>(items), compare) {}
   constexpr map(std::initializer_list<value_type> items)
       : map{items, Compare{}} {}
 
@@ -236,6 +241,12 @@ public:
   constexpr key_compare key_comp() const { return compare_; }
   constexpr key_compare value_comp() const { return compare_; }
 };
+
+template <typename T, typename U, std::size_t N>
+constexpr auto make_map(std::tuple<T, U> const (&items)[N]) {
+  return map<T, U, N>{bits::to_array(items)};
+}
+
 } // namespace frozen
 
 #endif

--- a/include/frozen/set.h
+++ b/include/frozen/set.h
@@ -25,6 +25,7 @@
 
 #include "bits/algorithms.h"
 #include <array>
+#include <utility>
 
 namespace frozen {
 
@@ -53,11 +54,19 @@ public:
 public:
   /* constructors */
   constexpr set(const set &other) = default;
-  constexpr set(std::initializer_list<Key> keys, Compare const &comp)
-      : compare_{comp}, keys_{bits::quicksort(
-                            bits::make_unordered_array<Key, N>(keys),
-                            compare_)} {}
-  constexpr set(std::initializer_list<Key> keys) : set{keys, Compare{}} {}
+
+  constexpr set(container_type keys, Compare const & comp)
+      : compare_{comp}
+      , keys_(bits::quicksort(container_type{keys}, compare_)) {}
+
+  explicit constexpr set(container_type keys)
+      : set{keys, Compare{}} {}
+
+  constexpr set(std::initializer_list<Key> list, Compare const & comp)
+      : set(bits::make_unordered_array<Key, N>(list), comp) {}
+
+  constexpr set(std::initializer_list<Key> list)
+      : set(bits::make_unordered_array<Key, N>(list)) {}
 
   /* capacity */
   constexpr bool empty() const { return !N; }
@@ -141,6 +150,9 @@ public:
 public:
   /* constructors */
   constexpr set(const set &other) = default;
+  constexpr set(std::array<Key, 0>, Compare const &) {}
+  explicit constexpr set(std::array<Key, 0>) {}
+
   constexpr set(std::initializer_list<Key>, Compare const &comp)
       : compare_{comp} {}
   constexpr set(std::initializer_list<Key> keys) : set{keys, Compare{}} {}
@@ -177,6 +189,12 @@ public:
   constexpr const_reverse_iterator rend() const { return nullptr; }
   constexpr const_reverse_iterator crend() const { return nullptr; }
 };
+
+template <typename T, std::size_t N>
+constexpr auto make_set(const T (&args)[N]) {
+  return set<T, N>(bits::to_array(args));
+}
+
 } // namespace frozen
 
 #endif

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -33,14 +33,17 @@
 namespace frozen {
 
 class string {
-  char const *const data_;
-  std::size_t const size_;
+  char const * data_;
+  std::size_t size_;
 
   public:
   constexpr string(char const *data, std::size_t size)
       : data_(data), size_(size) {}
 
   string(std::string const &s) : data_(s.data()), size_(s.size()) {}
+
+  constexpr string(const string &) noexcept = default;
+  constexpr string & operator=(const string &) noexcept = default;
 
   constexpr std::size_t size() const { return size_; }
 
@@ -53,6 +56,16 @@ class string {
       if (data_[i] != other.data_[i])
         return false;
     return true;
+  }
+
+  constexpr bool operator < (const string & other) const {
+    unsigned i = 0;
+    while (i < size() && i < other.size()) {
+      if ((*this)[i] < other[i]) { return true; }
+      if ((*this)[i] > other[i]) { return false; }
+      ++i;
+    }
+    return size() < other.size();
   }
 };
 

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -67,6 +67,10 @@ class string {
     }
     return size() < other.size();
   }
+
+  constexpr const char * data() const {
+    return data_;
+  }
 };
 
 template <> struct elsa<string> {

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -52,12 +52,11 @@ class unordered_map {
   container_type items_;
   tables_type tables_;
 
-  using pair_type = typename container_type::value_type;
-
 public:
   /* typedefs */
   using key_type = Key;
-  using value_type = Value;
+  using mapped_type = Value;
+  using value_type = typename container_type::value_type;
   using size_type = typename container_type::size_type;
   using difference_type = typename container_type::difference_type;
   using hasher = Hash;
@@ -77,17 +76,17 @@ public:
       : equal_{equal}
       , items_{items}
       , tables_{
-            bits::make_pmh_tables<pair_type, N, storage_size>(
+            bits::make_pmh_tables<value_type, N, storage_size>(
                 items_,
                 hash, bits::GetKey{})} {}
   explicit constexpr unordered_map(container_type items)
       : unordered_map{items, Hash{}, KeyEqual{}} {}
 
-  constexpr unordered_map(std::initializer_list<pair_type> items,
+  constexpr unordered_map(std::initializer_list<value_type> items,
                           Hash const & hash, KeyEqual const & equal)
-      : unordered_map{bits::make_unordered_array<pair_type, N>(items), hash, equal} {}
+      : unordered_map{bits::make_unordered_array<value_type, N>(items), hash, equal} {}
 
-  constexpr unordered_map(std::initializer_list<pair_type> items)
+  constexpr unordered_map(std::initializer_list<value_type> items)
       : unordered_map{items, Hash{}, KeyEqual{}} {}
 
   /* iterators */

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -76,9 +76,8 @@ public:
       : equal_{equal}
       , items_{items}
       , tables_{
-            bits::make_pmh_tables<value_type, N, storage_size>(
-                items_,
-                hash, bits::GetKey{})} {}
+            bits::make_pmh_tables<storage_size>(
+                items_, hash, bits::GetKey{})} {}
   explicit constexpr unordered_map(container_type items)
       : unordered_map{items, Hash{}, KeyEqual{}} {}
 

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -76,7 +76,7 @@ public:
                           KeyEqual const &equal)
       : equal_{equal}
       , items_(keys)
-      , tables_{bits::make_pmh_tables<Key, N, storage_size>(
+      , tables_{bits::make_pmh_tables<storage_size>(
             items_, hash, bits::Get{})} {}
   explicit constexpr unordered_set(container_type keys)
       : unordered_set{keys, Hash{}, KeyEqual{}} {}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SRCS=test_main.cpp test_set.cpp test_map.cpp test_unordered_set.cpp test_unordered_str_set.cpp test_unordered_map.cpp test_unordered_map_str.cpp test_str.cpp
+SRCS=test_main.cpp test_set.cpp test_map.cpp test_unordered_set.cpp test_str_set.cpp test_unordered_str_set.cpp test_unordered_map.cpp test_unordered_map_str.cpp test_str.cpp
 
 TARGET=test_main
 CXXFLAGS=-O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC
@@ -41,6 +41,12 @@ test_unordered_set.o: test_unordered_set.cpp \
   catch.hpp
 test_unordered_str_set.o: test_unordered_str_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
+  ../include/frozen/bits/algorithms.h \
+  ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
+  ../include/frozen/string.h \
+  catch.hpp
+test_str_set.o: test_str_set.cpp \
+  ../include/frozen/set.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   ../include/frozen/string.h \

--- a/tests/bench.hpp
+++ b/tests/bench.hpp
@@ -1,0 +1,65 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Extracted from google benchmarks suite
+// c.f. https://github.com/google/benchmark/blob/master/include/benchmark/benchmark_api.h
+//
+// These two functions DoNotOptimize and ClobberMemory prevent the compiler
+// from optimizing in certain ways.
+//
+// There is an excellent talk by Chandler Carruth about this here:
+// https://www.youtube.com/watch?v=nXaxk27zwlk
+
+#ifndef FROZEN_LETITGO_BENCH_HPP
+#define FROZEN_LETITGO_BENCH_HPP
+
+namespace benchmark {
+
+#if defined(__GNUC__)
+#define BENCHMARK_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define BENCHMARK_ALWAYS_INLINE
+#endif
+
+#if defined(__GNUC__)
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void
+DoNotOptimize(Tp const & value) {
+  asm volatile("" : : "g"(value) : "memory");
+}
+// Force the compiler to flush pending writes to global memory. Acts as an
+// effective read/write barrier
+inline BENCHMARK_ALWAYS_INLINE void
+ClobberMemory() {
+  asm volatile("" : : : "memory");
+}
+
+#else
+
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void
+DoNotOptimize(Tp const & value) {
+    static_cast<volatile void>(&reinterpret_cast<char const volatile&>(value)));
+}
+
+// TODO
+template <class Tp>
+inline BENCHMARK_ALWAYS_INLINE void
+ClobberMemory() {}
+
+#endif
+
+} // end namespace benchmark
+
+#endif

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -208,7 +208,6 @@ TEST_CASE("triple frozen map", "[map]") {
 
 TEST_CASE("frozen::map <> std::map", "[map]") {
 #define INIT_SEQ                                                               \
-  {                                                                            \
     {19, 12}, {1, 12}, {2, 12}, {4, 12}, {5, 12}, {6, 12}, {7, 12}, {8, 12},   \
         {9, 12}, {10, 12}, {11, 12}, {111, 12}, {1112, 12}, {1115, 12},        \
         {1118, 12}, {1110, 12}, {1977, 12}, {177, 12}, {277, 12}, {477, 12},   \
@@ -236,11 +235,10 @@ TEST_CASE("frozen::map <> std::map", "[map]") {
         {11779988, 12}, {111779988, 12}, {1112779988, 12}, {1115779988, 12},   \
         {1118779988, 12}, {                                                    \
       1110779988, 13                                                           \
-    }                                                                          \
-  }
+    }
 
-  const std::map<int, int> std_map = INIT_SEQ;
-  constexpr frozen::map<int, int, 128> frozen_map = INIT_SEQ;
+  const std::map<int, int> std_map = { INIT_SEQ };
+  constexpr frozen::map<int, int, 128> frozen_map = { INIT_SEQ };
   SECTION("checking size and content") {
     REQUIRE(std_map.size() == frozen_map.size());
     for (auto v : std_map)
@@ -277,5 +275,18 @@ TEST_CASE("frozen::map <> std::map", "[map]") {
     std::cout << "frozen::map<int, int>: " << frozen_duration << " ms"
               << std::endl;
     //REQUIRE(std_duration > frozen_duration);
+  }
+}
+
+TEST_CASE("frozen::map <> frozen::make_map", "[map]") {
+  constexpr frozen::map<int, int, 128> frozen_map = { INIT_SEQ };
+  constexpr auto frozen_map2 = frozen::make_map<int, int>({INIT_SEQ});
+
+  SECTION("checking size and content") {
+    REQUIRE(frozen_map.size() == frozen_map2.size());
+    for (auto v : frozen_map2)
+      REQUIRE(frozen_map.count(std::get<0>(v)));
+    for (auto v : frozen_map)
+      REQUIRE(frozen_map2.count(std::get<0>(v)));
   }
 }

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -52,7 +52,7 @@ TEST_CASE("empty frozen map", "[map]") {
   std::for_each(ze_map.begin(), ze_map.end(), [](std::tuple<int, float>) {});
   REQUIRE(std::distance(ze_map.rbegin(), ze_map.rend()) == 0);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
-                     std::make_tuple(3, 5.3)) == 0);
+                     decltype(ze_map)::value_type(3, 5.3)) == 0);
 }
 
 TEST_CASE("singleton frozen map", "[map]") {
@@ -124,9 +124,9 @@ TEST_CASE("singleton frozen map", "[map]") {
   std::for_each(ze_map.begin(), ze_map.end(), [](std::tuple<int, float>) {});
   REQUIRE(std::distance(ze_map.rbegin(), ze_map.rend()) == 1);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
-                     std::make_tuple(3, 14)) == 0);
+                     decltype(ze_map)::value_type(3, 14)) == 0);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
-                     std::make_tuple(1, 3.14)) == 1);
+                     decltype(ze_map)::value_type(1, 3.14)) == 1);
 }
 
 TEST_CASE("triple frozen map", "[map]") {
@@ -201,9 +201,9 @@ TEST_CASE("triple frozen map", "[map]") {
   std::for_each(ze_map.begin(), ze_map.end(), [](std::tuple<long, bool>) {});
   REQUIRE(std::distance(ze_map.rbegin(), ze_map.rend()) == ze_map.size());
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
-                     std::make_tuple(3, 14)) == 0);
+                     decltype(ze_map)::value_type(3, 14)) == 0);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
-                     std::make_tuple(20, false)) == 1);
+                     decltype(ze_map)::value_type(20, false)) == 1);
 }
 
 TEST_CASE("frozen::map <> std::map", "[map]") {

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 
+#include "bench.hpp"
 #include "catch.hpp"
 
 TEST_CASE("empty frozen map", "[map]") {
@@ -251,8 +252,11 @@ TEST_CASE("frozen::map <> std::map", "[map]") {
   SECTION("printing minimal performance requirements") {
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto c = std_map.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(std_map.count(i + j));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
@@ -261,8 +265,11 @@ TEST_CASE("frozen::map <> std::map", "[map]") {
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto c = frozen_map.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(frozen_map.count(i + j));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -276,6 +276,11 @@ TEST_CASE("frozen::map <> std::map", "[map]") {
               << std::endl;
     //REQUIRE(std_duration > frozen_duration);
   }
+
+  static_assert(std::is_same<typename decltype(std_map)::key_type,
+                             typename decltype(frozen_map)::key_type>::value, "");
+  static_assert(std::is_same<typename decltype(std_map)::mapped_type,
+                             typename decltype(frozen_map)::mapped_type>::value, "");
 }
 
 TEST_CASE("frozen::map <> frozen::make_map", "[map]") {

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -253,3 +253,16 @@ TEST_CASE("frozen::set <> std::set", "[set]") {
     REQUIRE(std_duration > frozen_duration);
   }
 }
+
+TEST_CASE("frozen::set <> frozen::make_set", "[set]") {
+  constexpr frozen::set<int, 128> frozen_set = { INIT_SEQ };
+  constexpr auto frozen_set2 = frozen::make_set<int>({INIT_SEQ});
+
+  SECTION("checking size and content") {
+    REQUIRE(frozen_set.size() == frozen_set2.size());
+    for (auto v : frozen_set2)
+      REQUIRE(frozen_set.count(v));
+    for (auto v : frozen_set)
+      REQUIRE(frozen_set2.count(v));
+  }
+}

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <set>
 
+#include "bench.hpp"
 #include "catch.hpp"
 
 TEST_CASE("empty frozen set", "[set]") {
@@ -225,8 +226,11 @@ TEST_CASE("frozen::set <> std::set", "[set]") {
   SECTION("printing minimal performance requirements") {
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto __attribute__((unused)) c = std_set.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(std_set.count(i+j));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
@@ -235,14 +239,17 @@ TEST_CASE("frozen::set <> std::set", "[set]") {
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto __attribute__((unused)) c = frozen_set.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(frozen_set.count(i + j));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =
         std::chrono::duration<double, std::milli>(frozen_diff).count();
     std::cout << "frozen::set<int>: " << frozen_duration << " ms" << std::endl;
 
-    //REQUIRE(std_duration > frozen_duration);
+    REQUIRE(std_duration > frozen_duration);
   }
 }

--- a/tests/test_str.cpp
+++ b/tests/test_str.cpp
@@ -2,6 +2,8 @@
 #include <string>
 #include <chrono>
 #include <iostream>
+
+#include "bench.hpp"
 #include "catch.hpp"
 
 using namespace frozen::string_literals;
@@ -41,7 +43,8 @@ TEST_CASE("str str perf", "[str-search-perf]") {
     haystack = "AAAAAAAAAAAAAAAA" + haystack;
 
   auto std_start = std::chrono::steady_clock::now();
-  volatile int k = haystack.find("ABCDABD");
+  benchmark::DoNotOptimize(haystack);
+  benchmark::DoNotOptimize(haystack.find("ABCDABD"));
   auto std_stop = std::chrono::steady_clock::now();
   auto std_diff = std_stop - std_start;
   auto std_duration =
@@ -49,7 +52,8 @@ TEST_CASE("str str perf", "[str-search-perf]") {
   std::cout << "str search: " << std_duration << " ms" << std::endl;
 
   auto frozen_start = std::chrono::steady_clock::now();
-  volatile auto __attribute__((unused)) j = frozen::search(haystack.begin(), haystack.end(), frozen::make_needle("ABCDABD"));
+  benchmark::DoNotOptimize(haystack);
+  benchmark::DoNotOptimize(frozen::search(haystack.begin(), haystack.end(), frozen::make_needle("ABCDABD")));
   auto frozen_stop = std::chrono::steady_clock::now();
   auto frozen_diff = frozen_stop - frozen_start;
   auto frozen_duration =

--- a/tests/test_str_set.cpp
+++ b/tests/test_str_set.cpp
@@ -1,0 +1,115 @@
+#include <chrono>
+#include <frozen/string.h>
+#include <frozen/set.h>
+#include <iostream>
+#include <set>
+
+#include "bench.hpp"
+#include "catch.hpp"
+
+using namespace frozen::string_literals;
+
+TEST_CASE("tripleton int frozen ordered set", "[set]") {
+  constexpr frozen::set<frozen::string, 3> ze_set{"1"_s, "2"_s, "3"_s};
+
+  constexpr auto empty = ze_set.empty();
+  REQUIRE(!empty);
+
+  constexpr auto size = ze_set.size();
+  REQUIRE(size == 3);
+
+  constexpr auto max_size = ze_set.max_size();
+  REQUIRE(max_size == 3);
+
+  constexpr auto nocount = ze_set.count("4"_s);
+  REQUIRE(nocount == 0);
+
+  constexpr auto count = ze_set.count("1"_s);
+  REQUIRE(count == 1);
+
+  auto notfound = ze_set.find("4"_s);
+  REQUIRE(notfound == ze_set.end());
+
+  auto found = ze_set.find("1"_s);
+  REQUIRE(found == ze_set.begin());
+
+  auto range = ze_set.equal_range("1"_s);
+  REQUIRE(std::get<0>(range) != ze_set.end());
+
+  auto begin = ze_set.begin(), end = ze_set.end();
+  REQUIRE(begin != end);
+
+  auto cbegin = ze_set.cbegin(), cend = ze_set.cend();
+  REQUIRE(cbegin != cend);
+
+  std::for_each(ze_set.begin(), ze_set.end(), [](frozen::string const &) {});
+}
+
+TEST_CASE("frozen::set<str> <> std::set",
+          "[set]") {
+#define INIT_SEQ                                                               \
+  "19"_s, "1"_s, "2"_s, "4"_s, "5"_s, "6"_s, "7"_s, "8"_s, "9"_s, "10"_s,      \
+      "11"_s, "111"_s, "1112"_s, "1115"_s, "1118"_s, "1110"_s, "1977"_s,       \
+      "177"_s, "277"_s, "477"_s, "577"_s, "677"_s, "777"_s, "877"_s, "977"_s,  \
+      "1077"_s, "1177"_s, "11177"_s, "111277"_s, "111577"_s, "111877"_s,       \
+      "111077"_s, "1999"_s, "199"_s, "299"_s, "499"_s, "599"_s, "699"_s,       \
+      "799"_s, "899"_s, "999"_s, "1099"_s, "1199"_s, "11199"_s, "111299"_s,    \
+      "111599"_s, "111899"_s, "111099"_s, "197799"_s, "17799"_s, "27799"_s,    \
+      "47799"_s, "57799"_s, "67799"_s, "77799"_s, "87799"_s, "97799"_s,        \
+      "107799"_s, "117799"_s, "1117799"_s, "11127799"_s, "11157799"_s,         \
+      "11187799"_s, "11107799"_s, "1988"_s, "188"_s, "288"_s, "488"_s,         \
+      "588"_s, "688"_s, "788"_s, "888"_s, "988"_s, "1088"_s, "1188"_s,         \
+      "11188"_s, "111288"_s, "111588"_s, "111888"_s, "111088"_s, "197788"_s,   \
+      "17788"_s, "27788"_s, "47788"_s, "57788"_s, "67788"_s, "77788"_s,        \
+      "87788"_s, "97788"_s, "107788"_s, "117788"_s, "1117788"_s, "11127788"_s, \
+      "11157788"_s, "11187788"_s, "11107788"_s, "199988"_s, "19988"_s,         \
+      "29988"_s, "49988"_s, "59988"_s, "69988"_s, "79988"_s, "89988"_s,        \
+      "99988"_s, "109988"_s, "119988"_s, "1119988"_s, "11129988"_s,            \
+      "11159988"_s, "11189988"_s, "11109988"_s, "19779988"_s, "1779988"_s,     \
+      "2779988"_s, "4779988"_s, "5779988"_s, "6779988"_s, "7779988"_s,         \
+      "8779988"_s, "9779988"_s, "10779988"_s, "11779988"_s, "111779988"_s,     \
+      "1112779988"_s, "1115779988"_s, "1118779988"_s, "1110779988"_s
+
+  const std::set<frozen::string> std_set = {INIT_SEQ};
+  constexpr frozen::set<frozen::string, 128> frozen_set = {INIT_SEQ};
+  SECTION("checking size and content") {
+    REQUIRE(std_set.size() == frozen_set.size());
+    for (auto v : std_set)
+      REQUIRE(frozen_set.count(v));
+
+    for (auto v : frozen_set)
+      REQUIRE(std_set.count(v));
+  }
+
+  SECTION("checking minimal performance requirements") {
+    std::array<frozen::string, 128> data{{INIT_SEQ}};
+
+    auto std_start = std::chrono::steady_clock::now();
+    for (int i = 0; i < 10000; ++i)
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(std_set.count(val));
+      }
+    auto std_stop = std::chrono::steady_clock::now();
+    auto std_diff = std_stop - std_start;
+    auto std_duration =
+        std::chrono::duration<double, std::milli>(std_diff).count();
+    std::cout << "std::set<str>: " << std_duration << " ms"
+              << std::endl;
+
+    auto frozen_start = std::chrono::steady_clock::now();
+    for (int i = 0; i < 10000; ++i)
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(frozen_set.count(val));
+      }
+    auto frozen_stop = std::chrono::steady_clock::now();
+    auto frozen_diff = frozen_stop - frozen_start;
+    auto frozen_duration =
+        std::chrono::duration<double, std::milli>(frozen_diff).count();
+    std::cout << "frozen::set<str>: " << frozen_duration << " ms"
+              << std::endl;
+
+    // REQUIRE(std_duration > frozen_duration);
+  }
+}

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -51,6 +51,9 @@ TEST_CASE("singleton frozen unordered map", "[unordered map]") {
   REQUIRE(cbegin < cend);
 
   std::for_each(ze_map.begin(), ze_map.end(), [](std::tuple<int, float>) {});
+
+  static_assert(std::is_same<typename decltype(ze_map)::key_type, int>::value, "");
+  static_assert(std::is_same<typename decltype(ze_map)::mapped_type, double>::value, "");
 }
 
 TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
@@ -124,6 +127,11 @@ TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
 
     // REQUIRE(std_duration > frozen_duration);
   }
+
+  static_assert(std::is_same<typename decltype(std_map)::key_type,
+                             typename decltype(frozen_map)::key_type>::value, "");
+  static_assert(std::is_same<typename decltype(std_map)::mapped_type,
+                             typename decltype(frozen_map)::mapped_type>::value, "");
 }
 
 TEST_CASE("frozen::unordered_map <> frozen::make_unordered_map", "[unordered_map]") {

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -55,7 +55,6 @@ TEST_CASE("singleton frozen unordered map", "[unordered map]") {
 
 TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
 #define INIT_SEQ                                                               \
-  {                                                                            \
     {19, 12}, {1, 12}, {2, 12}, {4, 12}, {5, 12}, {6, 12}, {7, 12}, {8, 12},   \
         {9, 12}, {10, 12}, {11, 12}, {111, 12}, {1112, 12}, {1115, 12},        \
         {1118, 12}, {1110, 12}, {1977, 12}, {177, 12}, {277, 12}, {477, 12},   \
@@ -83,11 +82,10 @@ TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
         {11779988, 12}, {111779988, 12}, {1112779988, 12}, {1115779988, 12},   \
         {1118779988, 12}, {                                                    \
       1110779988, 13                                                           \
-    }                                                                          \
-  }
+    }
 
-  const std::unordered_map<int, int> std_map = INIT_SEQ;
-  constexpr frozen::unordered_map<int, int, 128> frozen_map = INIT_SEQ;
+  const std::unordered_map<int, int> std_map = { INIT_SEQ };
+  constexpr frozen::unordered_map<int, int, 128> frozen_map = { INIT_SEQ };
   SECTION("checking size and content") {
     REQUIRE(std_map.size() == frozen_map.size());
     for (auto v : std_map)
@@ -125,5 +123,18 @@ TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
     std::cout << "frozen::unordered_map<int, int>: " << frozen_duration << " ms" << std::endl;
 
     // REQUIRE(std_duration > frozen_duration);
+  }
+}
+
+TEST_CASE("frozen::unordered_map <> frozen::make_unordered_map", "[unordered_map]") {
+  constexpr frozen::unordered_map<int, int, 128> frozen_map = { INIT_SEQ };
+  constexpr auto frozen_map2 = frozen::make_unordered_map<int, int>({INIT_SEQ});
+
+  SECTION("checking size and content") {
+    REQUIRE(frozen_map.size() == frozen_map2.size());
+    for (auto v : frozen_map2)
+      REQUIRE(frozen_map.count(std::get<0>(v)));
+    for (auto v : frozen_map)
+      REQUIRE(frozen_map2.count(std::get<0>(v)));
   }
 }

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "bench.hpp"
 #include "catch.hpp"
 TEST_CASE("singleton frozen unordered map", "[unordered map]") {
   constexpr frozen::unordered_map<int, double, 1> ze_map{{1, 2.}};
@@ -98,21 +99,31 @@ TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
   SECTION("checking minimal performance requirements") {
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto c = std_map.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(std_map.count(i + j));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
         std::chrono::duration<double, std::milli>(std_diff).count();
+    std::cout << "std::unordered_map<int, int>: " << std_duration << " ms" << std::endl;
+
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto c = frozen_map.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(frozen_map.count(i + j));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =
         std::chrono::duration<double, std::milli>(frozen_diff).count();
-    REQUIRE(std_duration > frozen_duration);
+    std::cout << "frozen::unordered_map<int, int>: " << frozen_duration << " ms" << std::endl;
+
+    // REQUIRE(std_duration > frozen_duration);
   }
 }

--- a/tests/test_unordered_map_str.cpp
+++ b/tests/test_unordered_map_str.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "bench.hpp"
 #include "catch.hpp"
 using namespace frozen::string_literals;
 
@@ -73,9 +74,10 @@ TEST_CASE("frozen::unordered_map<str, int> <> std::unordered_map",
     std::initializer_list<std::pair<frozen::string, int>> data = {INIT_SEQ};
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (auto val : data)
-        volatile const auto __attribute__((unused)) c =
-            std_map.count(val.first);
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(std_map.count(val.first));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
@@ -85,9 +87,10 @@ TEST_CASE("frozen::unordered_map<str, int> <> std::unordered_map",
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (auto val : data)
-        volatile const auto __attribute__((unused)) c =
-            frozen_map.count(val.first);
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(frozen_map.count(val.first));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -156,3 +156,16 @@ TEST_CASE("frozen::unordered_set<int> <> std::unordered_set",
     REQUIRE(std_duration > frozen_duration);
   }
 }
+
+TEST_CASE("frozen::unordered_set <> frozen::make_unordered_set", "[unordered_set]") {
+  constexpr frozen::unordered_set<int, 129> frozen_set = { INIT_SEQ };
+  constexpr auto frozen_set2 = frozen::make_unordered_set<int>({INIT_SEQ});
+
+  SECTION("checking size and content") {
+    REQUIRE(frozen_set.size() == frozen_set2.size());
+    for (auto v : frozen_set2)
+      REQUIRE(frozen_set.count(v));
+    for (auto v : frozen_set)
+      REQUIRE(frozen_set2.count(v));
+  }
+}

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <unordered_set>
 
+#include "bench.hpp"
 #include "catch.hpp"
 
 TEST_CASE("singleton frozen unordered set", "[unordered set]") {
@@ -126,8 +127,11 @@ TEST_CASE("frozen::unordered_set<int> <> std::unordered_set",
   SECTION("checking minimal performance requirements") {
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto __attribute__((unused)) c = std_set.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(std_set.count(i + j));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
@@ -137,8 +141,11 @@ TEST_CASE("frozen::unordered_set<int> <> std::unordered_set",
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (int j = 0; j < 10000; ++j)
-        volatile const auto __attribute__((unused)) c = frozen_set.count(i + j);
+      for (int j = 0; j < 10000; ++j) {
+        benchmark::DoNotOptimize(i);
+        benchmark::DoNotOptimize(j);
+        benchmark::DoNotOptimize(frozen_set.count(i + j));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =

--- a/tests/test_unordered_str_set.cpp
+++ b/tests/test_unordered_str_set.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <unordered_set>
 
+#include "bench.hpp"
 #include "catch.hpp"
 
 using namespace frozen::string_literals;
@@ -94,8 +95,10 @@ TEST_CASE("frozen::unordered_set<str> <> std::unordered_set",
 
     auto std_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (auto val : data)
-        volatile const auto __attribute__((unused)) c = std_set.count(val);
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(std_set.count(val));
+      }
     auto std_stop = std::chrono::steady_clock::now();
     auto std_diff = std_stop - std_start;
     auto std_duration =
@@ -105,8 +108,10 @@ TEST_CASE("frozen::unordered_set<str> <> std::unordered_set",
 
     auto frozen_start = std::chrono::steady_clock::now();
     for (int i = 0; i < 10000; ++i)
-      for (auto val : data)
-        volatile const auto __attribute__((unused)) c = frozen_set.count(val);
+      for (auto val : data) {
+        benchmark::DoNotOptimize(val);
+        benchmark::DoNotOptimize(frozen_set.count(val));
+      }
     auto frozen_stop = std::chrono::steady_clock::now();
     auto frozen_diff = frozen_stop - frozen_start;
     auto frozen_duration =


### PR DESCRIPTION
- Use google benchmark optimization barriers in benchmark tests
  When I started messing around with idea in #21 , I wanted to be sure that the decline in benchmark quality was real, so I used this code that I saw originally in a talk on benchmarking by Chandler Carruth (see code comment for link). I also used this benchmarking approach in a different library: https://github.com/cbeck88/strict-variant I didn't see any change in the results over your "volatile void" approach though, but I thought I would send it upstream anyways.

- Add array ctors, `make_X` factory functions
  This gives new ways of constructing a `frozen::set`, etc.
  It makes a frozen container constructible from the `container_type`, which is a `std::array`, in addition to `std::initializer_list`. This is helpful because you may have a `constexpr` function which produces a `std::array` which you would like to store in a set, but there is no way to construct an `initializer_list` from a `std::array`.
  On top of this is added a more DRY way of creating frozen objects: If you write `constexpr auto my_set = frozen::make_set<int>({1, 2, 3})` then you don't have to specify the `N` template parameter, the compiler can deduce it.

- Fix a bug with the standard container typedefs of `frozen::unordered_map`