### PR TITLE
use "multiply-shift" hashing in elsa, and other PMH development

### DIFF
--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -43,6 +43,11 @@ auto constexpr next_highest_power_of_two(std::size_t v) {
   return v;
 }
 
+inline constexpr unsigned log_base_two(std::size_t n) {
+  if (n > 1) { return 1 + log_base_two(n >> 1); }
+  return 0;
+}
+
 template <class T, std::size_t N, class Iter, std::size_t... I>
 constexpr std::array<T, N> make_unordered_array(Iter &iter,
                                                 std::index_sequence<I...>) {

--- a/include/frozen/bits/elsa.h
+++ b/include/frozen/bits/elsa.h
@@ -31,6 +31,7 @@ template <class T> struct elsa {
 
   constexpr std::size_t operator()(T const &value) const { return value; }
 
+/*
   constexpr std::size_t operator()(T const &value, std::size_t seed) const {
     std::size_t key = seed ^ value;
     key = (~key) + (key << 21); // key = (key << 21) - key - 1;
@@ -42,6 +43,7 @@ template <class T> struct elsa {
     key = key + (key << 31);
     return key;
   }
+*/
 };
 
 template <class T> using anna = elsa<T>;

--- a/include/frozen/bits/multiply_shift.h
+++ b/include/frozen/bits/multiply_shift.h
@@ -24,22 +24,43 @@
 #define FROZEN_LETITGO_MULTIPLY_SHIFT_H
 
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 
 namespace frozen {
 namespace bits {
 
+// Take an unseeded hash, and make it seeded using a 64 bit multiply-shift
 template <class Hash, unsigned num_bits>
-struct multiply_shift {
-  Hash hash;
+struct multiply_shift : Hash {
+  constexpr multiply_shift(Hash h) : Hash(h) {}
 
   template <typename T>
   constexpr uint64_t operator()(const T & t, uint64_t seed) const {
+    const Hash & hash = *this;
     return (hash(t) * seed) >> (64 - num_bits);
   }
 };
 
-template <unsigned num_bits, class Hash>
-constexpr multiply_shift<Hash, num_bits> adapt_hash(Hash h) {
+// Detection idiom to detect if a hash object supports seeds
+template <class... Ts>
+using void_t = void;
+
+template <class Hasher, class Key, class=void>
+struct supports_seeds : std::false_type{};
+
+template <class Hasher, class Key>
+struct supports_seeds<Hasher, Key, void_t<decltype(std::declval<Hasher>()(std::declval<Key>(), uint64_t{}))>>
+: std::true_type{};
+
+// Adapt a hash only if necessary
+template <unsigned num_bits, class Key, class Hash, std::enable_if_t<supports_seeds<Hash, Key>::value>* = nullptr>
+constexpr Hash maybe_adapt_hash(Hash h) {
+  return h;
+}
+
+template <unsigned num_bits, class Key, class Hash, std::enable_if_t<!supports_seeds<Hash, Key>::value>* = nullptr>
+constexpr multiply_shift<Hash, num_bits> maybe_adapt_hash(Hash h) {
   return {h};
 }
 

--- a/include/frozen/bits/multiply_shift.h
+++ b/include/frozen/bits/multiply_shift.h
@@ -1,0 +1,49 @@
+/*
+ * Frozen
+ * Copyright 2016 QuarksLab
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_MULTIPLY_SHIFT_H
+#define FROZEN_LETITGO_MULTIPLY_SHIFT_H
+
+#include <cstdint>
+
+namespace frozen {
+namespace bits {
+
+template <class Hash, unsigned num_bits>
+struct multiply_shift {
+  Hash hash;
+
+  template <typename T>
+  constexpr uint64_t operator()(const T & t, uint64_t seed) const {
+    return (hash(t) * seed) >> (64 - num_bits);
+  }
+};
+
+template <unsigned num_bits, class Hash>
+constexpr multiply_shift<Hash, num_bits> adapt_hash(Hash h) {
+  return {h};
+}
+
+} // end namespace bits
+} // end namespace frozen
+
+#endif

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -78,11 +78,12 @@ struct pmh_tables {
   }
 };
 
-template <std::size_t M, class Item, std::size_t N, class Hash, class Key>
+template <std::size_t M, class Item, std::size_t N, class Hash, class Key, class PRG>
 pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
                                                                items,
                                                            Hash const &hash,
-                                                           Key const &key) {
+                                                           Key const &key,
+                                                           PRG prg) {
   // Step 1: Place all of the keys into buckets
   cvector<bucket<M>, M> buckets;
   cvector<uint64_t, M> values;
@@ -103,7 +104,7 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
     if (bsize > 1) {
       // Repeatedly try different values of d until we find a hash function
       // that places all items in the bucket into free slots
-      std::size_t d = 1;
+      uint64_t d = prg();
       cvector<std::size_t, M> slots;
 
       while (slots.size() < bsize) {
@@ -111,7 +112,7 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
 
         if (values[slot] != 0 || !all_different_from(slots, slot)) {
           slots.clear();
-          d++;
+          d = prg();
           continue;
         }
 

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -64,6 +64,7 @@ struct maybe_seed {
 // Represents the two hash tables created by pmh algorithm
 template <std::size_t M, class Hasher>
 struct pmh_tables {
+  uint64_t first_seed_;
   std::array<maybe_seed, M> first_table_;
   std::array<uint64_t, M> second_table_;
   Hasher hash_;
@@ -72,11 +73,29 @@ struct pmh_tables {
   // Always returns a valid index, must use KeyEqual test after to confirm.
   template <typename KeyType>
   constexpr uint64_t lookup(const KeyType & key) const {
-    auto const & d = first_table_[hash_(key) % M];
+    auto const & d = first_table_[hash_(key, first_seed_) % M];
     if (!d.is_seed) { return d.value; }
     return second_table_[hash_(key, d.value) % M];
   }
 };
+
+template <std::size_t M>
+constexpr bool bucket_score_is_good(const cvector<bucket<M>, M> & buckets, uint64_t limit) {
+  uint64_t sum = 0;
+
+  unsigned b = 0;
+  for (; b < M; ++b) {
+    unsigned temp = buckets[b].size();
+    if (temp > 1) {
+        if (temp > limit) { return false; }
+        temp *= temp;
+        if (temp > limit) { return false; }
+        sum += temp;
+        if (sum > limit) { return false; }
+    }
+  }
+  return true;
+}
 
 template <std::size_t M, class Item, std::size_t N, class Hash, class Key, class PRG>
 pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
@@ -85,12 +104,22 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
                                                            Key const &key,
                                                            PRG prg) {
   // Step 1: Place all of the keys into buckets
+  uint64_t first_seed = 0;
   cvector<bucket<M>, M> buckets;
+
+  // Goal: Sum of squares of bucket sizes (for buckets >= 2) not more than 10 * N
+  constexpr uint64_t bucket_score_limit = 10 * N;
 
   auto *it = &std::get<0>(items);
 
-  for (std::size_t i = 0; i < N; ++i)
-    buckets[hash(key(it[i])) % M].push_back(1 + i);
+  do {
+    first_seed = prg();
+    buckets = {};
+
+    for (std::size_t i = 0; i < N; ++i)
+      buckets[hash(key(it[i]), first_seed) % M].push_back(1 + i);
+
+  } while(!bucket_score_is_good(buckets, bucket_score_limit));
 
   // Step 2: Sort the buckets and process the ones with the most items first.
   bits::quicksort(buckets.begin(), buckets.begin() + M - 1, bucket_size_compare{});
@@ -109,7 +138,7 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
       cvector<std::size_t, M> slots;
 
       while (slots.size() < bsize) {
-        auto slot = hash(key(it[bucket[slots.size()] - 1]), d) % M;
+        std::size_t slot = hash(key(it[bucket[slots.size()] - 1]), d) % M;
 
         if (values[slot] != 0 || !all_different_from(slots, slot)) {
           slots.clear();
@@ -120,19 +149,24 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
         slots.push_back(slot);
       }
 
-      G[hash(key(it[bucket[0] - 1])) % M] = maybe_seed{true, d};
+      G[hash(key(it[bucket[0] - 1]), first_seed) % M] = maybe_seed{true, d};
       for (std::size_t i = 0; i < bsize; ++i)
         values[slots[i]] = bucket[i];
     } else if (bsize == 1) {
-      G[hash(key(it[bucket[0] - 1])) % M] = maybe_seed{false, bucket[0] - 1};
+      G[hash(key(it[bucket[0] - 1]), first_seed) % M] = maybe_seed{false, bucket[0] - 1};
     }
   }
 
+  // Step 3: Adjust the values down by one. This is because when we originally pushed
+  // item sinto buckets, we pushed back 1+i.
+  //
+  // It is okay to send "empty" values to 0, because after any lookup, KeyEqual will (must)
+  // be used to check if we actually found the desired key.
   for (std::size_t i = 0; i < M; ++i)
     if (values[i])
       values[i]--;
 
-  return {G.to_array(), values.to_array(), hash};
+  return {first_seed, G.to_array(), values.to_array(), hash};
 }
 
 } // namespace bits

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -86,8 +86,6 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
                                                            PRG prg) {
   // Step 1: Place all of the keys into buckets
   cvector<bucket<M>, M> buckets;
-  cvector<uint64_t, M> values;
-  cvector<maybe_seed, M> G;
 
   auto *it = &std::get<0>(items);
 
@@ -96,6 +94,9 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const std::array<Item, N> &
 
   // Step 2: Sort the buckets and process the ones with the most items first.
   bits::quicksort(buckets.begin(), buckets.begin() + M - 1, bucket_size_compare{});
+
+  cvector<uint64_t, M> values;
+  cvector<maybe_seed, M> G;
 
   std::size_t b = 0;
   for (; b < M; ++b) {

--- a/include/frozen/bits/prg.h
+++ b/include/frozen/bits/prg.h
@@ -1,0 +1,51 @@
+/*
+ * Frozen
+ * Copyright 2016 QuarksLab
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_PRG_H
+#define FROZEN_LETITGO_PRG_H
+
+#include <cstdint>
+
+namespace frozen {
+namespace bits {
+
+// Parameters taken from
+// https://en.wikipedia.org/wiki/Linear_congruential_generator
+// Donald Knuth, MMIX generator
+
+struct LCG {
+  static constexpr uint64_t a = 6364136223846793005;
+  static constexpr uint64_t c = 1442695040888963407;
+
+  uint64_t value = 0;
+  
+  constexpr uint64_t operator()() {
+  	value *= a;
+  	value += c;
+  	return value;
+  }
+};
+
+} // namespace bits
+} // namespace frozen
+
+#endif

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "bits/algorithms.h"
+#include "bits/prg.h"
 
 namespace frozen {
 

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -48,7 +48,7 @@ class unordered_map {
   static constexpr std::size_t storage_size =
       bits::next_highest_power_of_two(N) * (N < 32 ? 2 : 1); // size adjustment to prevent high collision rate for small sets
   static constexpr unsigned hash_bits = bits::log_base_two(storage_size);
-  using AdaptedHash = bits::multiply_shift<Hash, hash_bits>;
+  using AdaptedHash = decltype(bits::maybe_adapt_hash<hash_bits, Key>(std::declval<Hash>()));
   using container_type = std::array<std::pair<Key, Value>, N>;
   using tables_type = bits::pmh_tables<storage_size, AdaptedHash>;
 
@@ -81,7 +81,7 @@ public:
       , items_{items}
       , tables_{
             bits::make_pmh_tables<storage_size>(
-                items_, bits::adapt_hash<hash_bits>(hash), bits::GetKey{}, bits::LCG{})} {}
+                items_, bits::maybe_adapt_hash<hash_bits, Key>(hash), bits::GetKey{}, bits::LCG{})} {}
   explicit constexpr unordered_map(container_type items)
       : unordered_map{items, Hash{}, KeyEqual{}} {}
 
@@ -138,7 +138,7 @@ public:
   constexpr std::size_t max_bucket_count() const { return storage_size; }
 
   /* observers*/
-  constexpr hasher hash_function() const { return tables_.hash_.hash; }
+  constexpr hasher hash_function() const { return tables_.hash_; }
   constexpr key_equal key_eq() const { return equal_; }
 
 private:

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -25,6 +25,7 @@
 #include <array>
 #include <frozen/bits/elsa.h>
 #include <frozen/bits/pmh.h>
+#include <frozen/bits/prg.h>
 #include <tuple>
 #include <functional>
 
@@ -77,7 +78,7 @@ public:
       , items_{items}
       , tables_{
             bits::make_pmh_tables<storage_size>(
-                items_, hash, bits::GetKey{})} {}
+                items_, hash, bits::GetKey{}, bits::LCG{})} {}
   explicit constexpr unordered_map(container_type items)
       : unordered_map{items, Hash{}, KeyEqual{}} {}
 

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -25,6 +25,7 @@
 #include <array>
 #include <frozen/bits/elsa.h>
 #include <frozen/bits/pmh.h>
+#include <frozen/bits/prg.h>
 
 #include <functional>
 #include <tuple>
@@ -77,7 +78,7 @@ public:
       : equal_{equal}
       , items_(keys)
       , tables_{bits::make_pmh_tables<storage_size>(
-            items_, hash, bits::Get{})} {}
+            items_, hash, bits::Get{}, bits::LCG{})} {}
   explicit constexpr unordered_set(container_type keys)
       : unordered_set{keys, Hash{}, KeyEqual{}} {}
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,6 +26,7 @@ test_unordered_map.o: test_unordered_map.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
   ../include/frozen/bits/prg.h \
+  ../include/frozen/bits/multiply_shift.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h \
   catch.hpp
@@ -33,18 +34,21 @@ test_unordered_map_str.o: test_unordered_map_str.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
   ../include/frozen/bits/prg.h \
+  ../include/frozen/bits/multiply_shift.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/string.h \
   catch.hpp
 test_unordered_set.o: test_unordered_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
   ../include/frozen/bits/prg.h \
+  ../include/frozen/bits/multiply_shift.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   catch.hpp
 test_unordered_str_set.o: test_unordered_str_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
   ../include/frozen/bits/prg.h \
+  ../include/frozen/bits/multiply_shift.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   ../include/frozen/string.h \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,22 +25,26 @@ test_set.o: test_set.cpp ../include/frozen/set.h \
 test_unordered_map.o: test_unordered_map.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
+  ../include/frozen/bits/prg.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h \
   catch.hpp
 test_unordered_map_str.o: test_unordered_map_str.cpp \
   ../include/frozen/unordered_map.h ../include/frozen/bits/elsa.h \
   ../include/frozen/bits/pmh.h \
+  ../include/frozen/bits/prg.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/string.h \
   catch.hpp
 test_unordered_set.o: test_unordered_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
+  ../include/frozen/bits/prg.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   catch.hpp
 test_unordered_str_set.o: test_unordered_str_set.cpp \
   ../include/frozen/unordered_set.h ../include/frozen/bits/pmh.h \
+  ../include/frozen/bits/prg.h \
   ../include/frozen/bits/algorithms.h \
   ../include/frozen/bits/basic_types.h ../include/frozen/bits/elsa.h \
   ../include/frozen/string.h \

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -56,6 +56,38 @@ TEST_CASE("singleton frozen unordered map", "[unordered map]") {
   static_assert(std::is_same<typename decltype(ze_map)::mapped_type, double>::value, "");
 }
 
+// This is mainly a test that construction does not time out
+TEST_CASE("frozen::unordered_map powers of two", "[unordered_map]") {
+    constexpr frozen::unordered_map<int, int, 14> frozen_map = {
+      {1, 0}, {2, 1}, {4, 2}, {8, 3}, {16, 4}, {32, 5}, {64, 6}, {128, 7},
+      {256, 8}, {512, 9}, {1024, 10}, {2048, 11}, {4096, 12}, {8192, 13}
+    };
+
+    for (const auto & pair : frozen_map) {
+      REQUIRE(pair.first == (1 << pair.second));
+    }
+}
+
+// This is also mainly a test that construction does not time out
+#define M64(X) { X * 64, X }
+TEST_CASE("frozen::unordered_map multiples of 64", "[unordered_map]") {
+    constexpr frozen::unordered_map<int, int, 57> frozen_map = {
+      M64(0), M64(1), M64(2), M64(3), M64(4), M64(5), M64(6), M64(7), M64(8),
+      M64(9), M64(10), M64(11), M64(12), M64(13), M64(14), M64(15), M64(16),
+      M64(17), M64(18), M64(19), M64(20), M64(21), M64(22), M64(23), M64(24),
+      M64(25), M64(26), M64(27), M64(28), M64(29), M64(30), M64(31), M64(32),
+      M64(33), M64(34), M64(35), M64(36), M64(37), M64(38), M64(39), M64(40),
+      M64(41), M64(42), M64(43), M64(44), M64(45), M64(46), M64(47), M64(48),
+      M64(49), M64(50), M64(51), M64(52), M64(53), M64(54), M64(55), M64(56),
+   };
+
+#  undef M64
+
+   for (const auto & pair : frozen_map) {
+     REQUIRE(pair.first == 64 * pair.second);
+   }
+}
+
 TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
 #define INIT_SEQ                                                               \
     {19, 12}, {1, 12}, {2, 12}, {4, 12}, {5, 12}, {6, 12}, {7, 12}, {8, 12},   \


### PR DESCRIPTION
This contains a bunch of experimental developments of the PMH routine

- We use a constexpr PRG to generate the seed attempts
- We change the way the "freelist" part of the algorithm works. When the first hash puts an item into a bucket alone, we make the number stored in that bucket refer to the actual data item in the *original* array. That way we can avoid placing that item into the second hash table at all.

The other big change is:
- We try to "randomize" the initial hash, and we reject it if we count that there are "too many" collisions. It is WIP to figure out exactly how that part should be done.
- We use "multiply-shift" hashing. The idea is that, this is super fast, and we have the opportunity to detect and recover from collisions at compile-time. I still think that "pairwise independence" etc. should be enough to achieve good performance. I need to add more tests of this to see if it is actually better.

Please let me test this some more, I just open the pull request so that you can see the commits nicely and see what I tried! We are NOT using this in production at tesla right now because I can't get this stuff to work in gcc 5, we are gonna wait until we do another compiler upgrade probly.