### PR TITLE
add a test of supposed "pathological inputs"

### DIFF
--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -56,6 +56,38 @@ TEST_CASE("singleton frozen unordered map", "[unordered map]") {
   static_assert(std::is_same<typename decltype(ze_map)::mapped_type, double>::value, "");
 }
 
+// This is mainly a test that construction does not time out
+TEST_CASE("frozen::unordered_map powers of two", "[unordered_map]") {
+    constexpr frozen::unordered_map<int, int, 14> frozen_map = {
+      {1, 0}, {2, 1}, {4, 2}, {8, 3}, {16, 4}, {32, 5}, {64, 6}, {128, 7},
+      {256, 8}, {512, 9}, {1024, 10}, {2048, 11}, {4096, 12}, {8192, 13}
+    };
+
+    for (const auto & pair : frozen_map) {
+      REQUIRE(pair.first == (1 << pair.second));
+    }
+}
+
+// This is also mainly a test that construction does not time out
+#define M64(X) { X * 64, X }
+TEST_CASE("frozen::unordered_map multiples of 64", "[unordered_map]") {
+    constexpr frozen::unordered_map<int, int, 57> frozen_map = {
+      M64(0), M64(1), M64(2), M64(3), M64(4), M64(5), M64(6), M64(7), M64(8),
+      M64(9), M64(10), M64(11), M64(12), M64(13), M64(14), M64(15), M64(16),
+      M64(17), M64(18), M64(19), M64(20), M64(21), M64(22), M64(23), M64(24),
+      M64(25), M64(26), M64(27), M64(28), M64(29), M64(30), M64(31), M64(32),
+      M64(33), M64(34), M64(35), M64(36), M64(37), M64(38), M64(39), M64(40),
+      M64(41), M64(42), M64(43), M64(44), M64(45), M64(46), M64(47), M64(48),
+      M64(49), M64(50), M64(51), M64(52), M64(53), M64(54), M64(55), M64(56),
+   };
+
+#  undef M64
+
+   for (const auto & pair : frozen_map) {
+     REQUIRE(pair.first == 64 * pair.second);
+   }
+}
+
 TEST_CASE("frozen::unordered_map <> std::unordered_map", "[unordered_map]") {
 #define INIT_SEQ                                                               \
     {19, 12}, {1, 12}, {2, 12}, {4, 12}, {5, 12}, {6, 12}, {7, 12}, {8, 12},   \


### PR DESCRIPTION
Based on my understanding of PMH implementation I think that these
should be "bad inputs" for current master, which would be "fixed"
by new_hashing2 PR. (These same examples compile fine there.)

Indeed, at current master, the second "hard input" causes compilation
failure on gcc and clang due to constexpr looping for too long,
even with very recent versions of gcc and clang. Here are logs:

With built-in apple clang:

    ~/frozen/tests$ c++ -v
    Apple LLVM version 9.0.0 (clang-900.0.38)
    Target: x86_64-apple-darwin16.7.0
    Thread model: posix
    InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
    ~/frozen/tests$ make clean
    rm -f *.o test_main
    ~/frozen/tests$ make
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_main.o test_main.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_set.o test_set.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_map.o test_map.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_unordered_set.o test_unordered_set.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_str_set.o test_str_set.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_unordered_str_set.o test_unordered_str_set.cpp
    c++ -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_unordered_map.o test_unordered_map.cpp
    test_unordered_map.cpp:74:51: error: constexpr variable 'frozen_map' must be initialized by a constant expression
    constexpr frozen::unordered_map<int, int, 57> frozen_map = {
                                                  ^            ~
    ../include/frozen/bits/elsa.h:34:76: note: constexpr evaluation hit maximum step limit; possible infinite loop?
      constexpr std::size_t operator()(T const &value, std::size_t seed) const {
                                                                               ^
    ../include/frozen/bits/pmh.h:105:19: note: in call to '&frozen::elsa<int>{}->operator()(frozen_map.items_.__elems_[7].first, 1770)'
          auto slot = hash(key(it[bucket[slots.size()] - 1]), d) % M;
                      ^
    ../include/frozen/unordered_map.h:79:13: note: in call to 'make_pmh_tables(frozen_map.items_, frozen::elsa<int>{}, bits::GetKey{})'
                bits::make_pmh_tables<storage_size>(
                ^
    ../include/frozen/unordered_map.h:86:9: note: in call to 'unordered_map({{{0, 0}, {64, 1}, {128, 2}, {192, 3}, {256, 4}, {320, 5}, {384, 6}, {448, 7}, {512, 8}, {576, 9},
          ...}}, frozen::elsa<int>{}, std::__1::equal_to<int>{})'
          : unordered_map{bits::make_unordered_array<value_type, N>(items), hash, equal} {}
            ^
    ../include/frozen/unordered_map.h:89:9: note: in call to 'unordered_map({&{{0 * 64, 0}, {1 * 64, 1}, {2 * 64, 2}, {3 * 64, 3}, {4 * 64, 4}, {5 * 64, 5}, {6 * 64, 6},
          {7 * 64, 7}, {8 * 64, 8}, {9 * 64, 9}, {10 * 64, 10}, {11 * 64, 11}, {12 * 64, 12}, {13 * 64, 13}, {14 * 64, 14}, {15 * 64, 15}, {16 * 64, 16}, {17 * 64, 17},
          {18 * 64, 18}, {19 * 64, 19}, {20 * 64, 20}, {21 * 64, 21}, {22 * 64, 22}, {23 * 64, 23}, {24 * 64, 24}, {25 * 64, 25}, {26 * 64, 26}, {27 * 64, 27}, {28 * 64, 28},
          {29 * 64, 29}, {30 * 64, 30}, {31 * 64, 31}, {32 * 64, 32}, {33 * 64, 33}, {34 * 64, 34}, {35 * 64, 35}, {36 * 64, 36}, {37 * 64, 37}, {38 * 64, 38}, {39 * 64, 39},
          {40 * 64, 40}, {41 * 64, 41}, {42 * 64, 42}, {43 * 64, 43}, {44 * 64, 44}, {45 * 64, 45}, {46 * 64, 46}, {47 * 64, 47}, {48 * 64, 48}, {49 * 64, 49}, {50 * 64, 50},
          {51 * 64, 51}, {52 * 64, 52}, {53 * 64, 53}, {54 * 64, 54}, {55 * 64, 55}, {56 * 64, 56}}[0], 57}, frozen::elsa<int>{}, std::__1::equal_to<int>{})'
          : unordered_map{items, Hash{}, KeyEqual{}} {}
            ^
    test_unordered_map.cpp:74:64: note: in call to 'unordered_map({&{{0 * 64, 0}, {1 * 64, 1}, {2 * 64, 2}, {3 * 64, 3}, {4 * 64, 4}, {5 * 64, 5}, {6 * 64, 6}, {7 * 64, 7},
          {8 * 64, 8}, {9 * 64, 9}, {10 * 64, 10}, {11 * 64, 11}, {12 * 64, 12}, {13 * 64, 13}, {14 * 64, 14}, {15 * 64, 15}, {16 * 64, 16}, {17 * 64, 17}, {18 * 64, 18},
          {19 * 64, 19}, {20 * 64, 20}, {21 * 64, 21}, {22 * 64, 22}, {23 * 64, 23}, {24 * 64, 24}, {25 * 64, 25}, {26 * 64, 26}, {27 * 64, 27}, {28 * 64, 28}, {29 * 64, 29},
          {30 * 64, 30}, {31 * 64, 31}, {32 * 64, 32}, {33 * 64, 33}, {34 * 64, 34}, {35 * 64, 35}, {36 * 64, 36}, {37 * 64, 37}, {38 * 64, 38}, {39 * 64, 39}, {40 * 64, 40},
          {41 * 64, 41}, {42 * 64, 42}, {43 * 64, 43}, {44 * 64, 44}, {45 * 64, 45}, {46 * 64, 46}, {47 * 64, 47}, {48 * 64, 48}, {49 * 64, 49}, {50 * 64, 50}, {51 * 64, 51},
          {52 * 64, 52}, {53 * 64, 53}, {54 * 64, 54}, {55 * 64, 55}, {56 * 64, 56}}[0], 57})'
        constexpr frozen::unordered_map<int, int, 57> frozen_map = {
                                                                   ^
    1 error generated.
    make: *** [test_unordered_map.o] Error 1

Now with homebrew gcc 7.2:

    ~/frozen/tests$ g++-7 -v
    Using built-in specs.
    COLLECT_GCC=g++-7
    COLLECT_LTO_WRAPPER=/usr/local/Cellar/gcc/7.2.0/libexec/gcc/x86_64-apple-darwin16.7.0/7.2.0/lto-wrapper
    Target: x86_64-apple-darwin16.7.0
    Configured with: ../configure --build=x86_64-apple-darwin16.7.0 --prefix=/usr/local/Cellar/gcc/7.2.0 --libdir=/usr/local/Cellar/gcc/7.2.0/lib/gcc/7 --enable-languages=c,c++,o$
    Thread model: posix
    gcc version 7.2.0 (Homebrew GCC 7.2.0)
    ~/frozen/tests$ make CXX=g++-7
    g++-7 -O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC -I../include  -c -o test_unordered_map.o test_unordered_map.cpp
    In file included from ../include/frozen/unordered_map.h:27:0,
                     from test_unordered_map.cpp:2:
    ../include/frozen/bits/pmh.h: In function 'void ____C_A_T_C_H____T_E_S_T____73()':
    test_unordered_map.cpp:82:4:   in constexpr expansion of 'frozen::unordered_map<int, int, 57>(std::initializer_list<std::pair<int, int> >{((const std::pair<int, int>*)(& ._70$
    ../include/frozen/unordered_map.h:89:48:   in constexpr expansion of '((frozen::unordered_map<int, int, 57>*)this)->frozen::unordered_map<int, int, 57>::unordered_map(items, $
    ../include/frozen/unordered_map.h:86:84:   in constexpr expansion of '((frozen::unordered_map<int, int, 57>*)this)->frozen::unordered_map<int, int, 57>::unordered_map(frozen:$
    ../include/frozen/unordered_map.h:79:48:   in constexpr expansion of 'frozen::bits::make_pmh_tables<64, std::pair<int, int>, 57, frozen::elsa<int>, frozen::bits::GetKey>(((co$
    ../include/frozen/bits/pmh.h:104:5: error: constexpr loop iteration count exceeds limit of 262144 (use -fconstexpr-loop-limit= to increase the limit)
         while (slots.size() < bsize) {
         ^~~~~
    make: *** [test_unordered_map.o] Error 1