### PR TITLE
constexpr-compatible linear congruantial engine

### DIFF
--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -43,6 +43,36 @@ auto constexpr next_highest_power_of_two(std::size_t v) {
   return v;
 }
 
+template<class T>
+auto constexpr log(T v) {
+  std::size_t n = 0;
+  while(v) {
+    n += 1;
+    v >>= 1;
+  }
+  return n;
+}
+
+constexpr std::size_t bit_weight(std::size_t n) {
+  return (n <= 8*sizeof(unsigned int))
+    + (n <= 8*sizeof(unsigned long))
+    + (n <= 8*sizeof(unsigned long long))
+    + (n <= 128);
+}
+
+unsigned int select_uint_least(std::integral_constant<std::size_t, 4>);
+unsigned long select_uint_least(std::integral_constant<std::size_t, 3>);
+unsigned long long select_uint_least(std::integral_constant<std::size_t, 2>);
+template<std::size_t N>
+unsigned long long select_uint_least(std::integral_constant<std::size_t, N>) {
+  static_assert(N < 2, "unsupported type size");
+  return {};
+}
+
+
+template<std::size_t N>
+using select_uint_least_t = decltype(select_uint_least(std::integral_constant<std::size_t, bit_weight(N)>()));
+
 template <class T, std::size_t N, class Iter, std::size_t... I>
 constexpr std::array<T, N> make_unordered_array(Iter &iter,
                                                 std::index_sequence<I...>) {

--- a/include/frozen/random.h
+++ b/include/frozen/random.h
@@ -1,0 +1,83 @@
+/*
+ * Frozen
+ * Copyright 2016 QuarksLab
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_RANDOM_H
+#define FROZEN_LETITGO_RANDOM_H
+
+#include <frozen/bits/algorithms.h>
+#include <cstdint>
+#include <type_traits>
+
+namespace frozen {
+template <class UIntType, UIntType a, UIntType c, UIntType m>
+class linear_congruential_engine {
+
+  static_assert(std::is_unsigned<UIntType>::value,
+                "UIntType must be an unsigned integral type");
+
+public:
+  using result_type = UIntType;
+  static constexpr result_type multiplier = a;
+  static constexpr result_type increment = c;
+  static constexpr result_type modulus = m;
+  static constexpr result_type default_seed = 1u;
+
+  linear_congruential_engine() = default;
+  constexpr linear_congruential_engine(result_type s) { seed(s); }
+
+  void seed(result_type s = default_seed) { state_ = s; }
+  constexpr result_type operator()() {
+	  using uint_least_t = bits::select_uint_least_t<bits::log(a) + bits::log(m) + 2>;
+    uint_least_t tmp = static_cast<uint_least_t>(multiplier) * state_ + increment;
+    if(modulus)
+      state_ = tmp % modulus;
+    else
+      state_ = tmp;
+    return state_;
+  }
+  constexpr void discard(unsigned long long n) {
+    while (n--)
+      operator()();
+  }
+  static constexpr result_type min() { return increment == 0u ? 1u : 0u; };
+  static constexpr result_type max() { return modulus - 1u; };
+  friend constexpr bool operator==(linear_congruential_engine const &self,
+                                   linear_congruential_engine const &other) {
+    return self.state_ == other.state_;
+  }
+  friend constexpr bool operator!=(linear_congruential_engine const &self,
+                                   linear_congruential_engine const &other) {
+    return !(self == other);
+  }
+
+private:
+  result_type state_ = default_seed;
+};
+
+using minstd_rand0 =
+    linear_congruential_engine<std::uint_fast32_t, 16807, 0, 2147483647>;
+using minstd_rand =
+    linear_congruential_engine<std::uint_fast32_t, 48271, 0, 2147483647>;
+
+} // namespace frozen
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SRCS=test_main.cpp test_set.cpp test_map.cpp test_unordered_set.cpp test_str_set.cpp test_unordered_str_set.cpp test_unordered_map.cpp test_unordered_map_str.cpp test_str.cpp
+SRCS=test_main.cpp test_rand.cpp test_set.cpp test_map.cpp test_unordered_set.cpp test_str_set.cpp test_unordered_str_set.cpp test_unordered_map.cpp test_unordered_map_str.cpp test_str.cpp
 
 TARGET=test_main
 CXXFLAGS=-O3 -Wall -std=c++14 -march=native -Wextra -W -Werror -Wshadow -fPIC
@@ -18,6 +18,10 @@ check:$(TARGET)
 	./$(TARGET)
 
 test_main.o: test_main.cpp catch.hpp
+test_rand.o: test_rand.cpp \
+	../include/frozen/random.h \
+	../include/frozen/bits/algorithms.h \
+	catch.hpp
 test_map.o: test_map.cpp ../include/frozen/map.h \
   ../include/frozen/bits/algorithms.h catch.hpp
 test_set.o: test_set.cpp ../include/frozen/set.h \

--- a/tests/test_rand.cpp
+++ b/tests/test_rand.cpp
@@ -1,0 +1,37 @@
+#include <algorithm>
+#include <chrono>
+#include <frozen/random.h>
+#include <iostream>
+#include <random>
+
+#include "bench.hpp"
+#include "catch.hpp"
+
+TEST_CASE("linear_congruential_engine", "[random]") {
+
+  frozen::linear_congruential_engine<std::uint32_t, 48271u, 0, 0x7fffffff> dist0;
+  std::linear_congruential_engine<std::uint32_t, 48271u, 0, 0x7fffffff> rdist0;
+  REQUIRE(dist0.min() == rdist0.min());
+  REQUIRE(dist0.max() == rdist0.max());
+  REQUIRE(dist0() == rdist0());
+  REQUIRE(dist0() == rdist0());
+  REQUIRE(dist0() == rdist0());
+
+  auto next0 = dist0();
+  dist0.discard(3);
+  rdist0.discard(4);
+  REQUIRE(dist0() == rdist0());
+
+  frozen::linear_congruential_engine<std::uint32_t, 48271u, 0, 0x7fffffff> odist0;
+  std::linear_congruential_engine<std::uint32_t, 48271u, 0, 0x7fffffff> ordist0;
+  REQUIRE(rdist0() != ordist0());
+  REQUIRE(dist0() != odist0());
+  REQUIRE(!(dist0() == odist0()));
+
+
+  frozen::minstd_rand dist1;
+  frozen::minstd_rand dist2;
+  frozen::linear_congruential_engine<std::size_t, 3, 3, 0> dist3;
+
+}
+


### PR DESCRIPTION
@cbeck88 this is an implementation of the std interface for the engine we care about. I used it in your headers and it works nice, so once this is merged, you can rebase on master.