### PR TITLE
fix: Remove superfluent parenthesis in bench for non-gcc platforms.

### DIFF
--- a/tests/bench.hpp
+++ b/tests/bench.hpp
@@ -50,7 +50,7 @@ ClobberMemory() {
 template <class Tp>
 inline BENCHMARK_ALWAYS_INLINE void
 DoNotOptimize(Tp const & value) {
-    static_cast<volatile void>(&reinterpret_cast<char const volatile&>(value)));
+    static_cast<volatile void>(&reinterpret_cast<char const volatile&>(value));
 }
 
 // TODO


### PR DESCRIPTION
I thought to give it a try on the latest MSVC 15.6 preview and stumbled upon superfluent parenthesis in bench.hpp.