### PR TITLE
gcc 8 unused variable warning

### DIFF
--- a/tests/test_unordered_map_str.cpp
+++ b/tests/test_unordered_map_str.cpp
@@ -83,4 +83,6 @@ TEST_CASE("various frozen::unordered_map config", "[unordered_map]") {
       {"nice damn shit", 14},
       {"pouet", 11},
   };
+  static_cast<void>(olaf0);
+  static_cast<void>(olaf1);
 }


### PR DESCRIPTION
fix GCC 8 compilation warnings