### PR TITLE
Fixed Exceptions check logic

### DIFF
--- a/include/frozen/bits/exceptions.h
+++ b/include/frozen/bits/exceptions.h
@@ -23,7 +23,7 @@
 #ifndef FROZEN_LETITGO_EXCEPTIONS_H
 #define FROZEN_LETITGO_EXCEPTIONS_H
 
-#if defined(FROZEN_NO_EXCEPTIONS) || (defined(_MSC_VER) && !defined(_CPPUNWIND)) || (defined(__cpp_exceptions) && __cpp_exceptions)
+#if defined(FROZEN_NO_EXCEPTIONS) || (defined(_MSC_VER) && !defined(_CPPUNWIND)) || (defined(__cpp_exceptions) && !__cpp_exceptions)
 
 #include <cstdlib>
 #define FROZEN_THROW_OR_ABORT(_) std::abort()


### PR DESCRIPTION
- Only force `std::abort()` over `throw` if `__cpp_exceptions`
  is disabled rather than enabled.