### PR TITLE
Fix build break with benchmark version v1.5.0

### DIFF
--- a/benchmarks/bench_main.cpp
+++ b/benchmarks/bench_main.cpp
@@ -1,3 +1,2 @@
 #include <benchmark/benchmark.h>
-BENCHMARK_MAIN()
-
+BENCHMARK_MAIN();


### PR DESCRIPTION
To fix this build break:

``` bash
In file included from /home/vagrant/open-source/infrastructure/frozen/benchmarks/bench_main.cpp:1:
/home/vagrant/open-source/infrastructure/frozen/benchmarks/bench_main.cpp:2:1: error: expected initializer at end of input
    2 | BENCHMARK_MAIN()
```

Google benchmark version: v1.5.0
G++ version: 9.2.1