### PR TITLE
Fix control flow around bucket overflows in make_pmh_buckets

### DIFF
--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -94,18 +94,23 @@ pmh_buckets<M> constexpr make_pmh_buckets(const carray<Item, N> & items,
                                 PRG & prg) {
   using result_t = pmh_buckets<M>;
   result_t result{};
+  bool rejected = false;
   // Continue until all items are placed without exceeding bucket_max
   while (1) {
     for (auto & b : result.buckets) {
       b.clear();
     }
     result.seed = prg();
+    rejected = false;
     for (std::size_t i = 0; i < N; ++i) {
       auto & bucket = result.buckets[hash(key(items[i]), static_cast<size_t>(result.seed)) % M];
-      if (bucket.size() >= result_t::bucket_max) { continue; }
+      if (bucket.size() >= result_t::bucket_max) {
+        rejected = true;
+        break;
+      }
       bucket.push_back(i);
     }
-    return result;
+    if (!rejected) { return result; }
   }
 }
 


### PR DESCRIPTION
This is a correctness issue reported in frozen issue #95

The issue is that the `continue` is meant to continue the outer
`while (1)` loop, so that we wipe out the buckets and try another
seed. As written, the code will simply not place the item that
overflowed. Then lookup of that item will likely fail.

I have never seen this happen in practice, I think because we
make the buckets pretty large, like sqrt(N), during the construction.
So likely overflow never occurs.
Otherwise I would expect the map to give a junk answer in practice.

I think I introduced this bug in this commit:
https://github.com/serge-sans-paille/frozen/commit/2897706fc23936a04666e9e9e3d60903c7866c7b#diff-b7220304cb6955468f4a0071ade6af7e