### PR TITLE
Added support for wide chars via frozen::wstring

### DIFF
--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -107,7 +107,7 @@ constexpr string operator"" _s(const char *data, std::size_t size) {
   return {data, size};
 }
 
-constexpr wstring operator"" _ws(const wchar_t *data, std::size_t size) {
+constexpr wstring operator"" _s(const wchar_t *data, std::size_t size) {
   return {data, size};
 }
 

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -111,6 +111,20 @@ constexpr wstring operator"" _s(const wchar_t *data, std::size_t size) {
   return {data, size};
 }
 
+constexpr u16string operator"" _s(const char16_t *data, std::size_t size) {
+  return {data, size};
+}
+
+constexpr u32string operator"" _s(const char32_t *data, std::size_t size) {
+  return {data, size};
+}
+
+#ifdef __cpp_char8_t
+constexpr u8string operator"" _s(const char8_t *data, std::size_t size) {
+  return {data, size};
+}
+#endif
+
 } // namespace string_literals
 
 } // namespace frozen

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -77,9 +77,6 @@ public:
   constexpr const chr_t *data() const { return data_; }
 };
 
-using string = basic_string<char>;
-using wstring = basic_string<wchar_t>;
-
 template <typename _CharT> struct elsa<basic_string<_CharT>> {
   constexpr std::size_t operator()(basic_string<_CharT> value) const {
     std::size_t d = 5381;
@@ -94,6 +91,15 @@ template <typename _CharT> struct elsa<basic_string<_CharT>> {
     return d;
   }
 };
+
+  using string = basic_string<char>;
+  using wstring = basic_string<wchar_t>;
+  using u16string = basic_string<char16_t>;
+  using u32string = basic_string<char32_t>;
+
+#ifdef __cpp_char8_t
+  using u8string = basic_string<char8_t>;
+#endif
 
 namespace string_literals {
 

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -92,13 +92,13 @@ template <typename _CharT> struct elsa<basic_string<_CharT>> {
   }
 };
 
-  using string = basic_string<char>;
-  using wstring = basic_string<wchar_t>;
-  using u16string = basic_string<char16_t>;
-  using u32string = basic_string<char32_t>;
+using string = basic_string<char>;
+using wstring = basic_string<wchar_t>;
+using u16string = basic_string<char16_t>;
+using u32string = basic_string<char32_t>;
 
 #ifdef __cpp_char8_t
-  using u8string = basic_string<char8_t>;
+using u8string = basic_string<char8_t>;
 #endif
 
 namespace string_literals {

--- a/tests/test_str.cpp
+++ b/tests/test_str.cpp
@@ -26,6 +26,80 @@ TEST_CASE("Various string operation", "[string]") {
   }
 }
 
+TEST_CASE("Various wstring operation", "[string]") {
+  {
+    frozen::wstring letItGo = L"Let it go !";
+    REQUIRE(letItGo == L"Let it go !");
+    REQUIRE(letItGo == L"Let it go !"_s);
+
+    letItGo = L"Let it go, let it go !";
+    REQUIRE(letItGo == L"Let it go, let it go !");
+    REQUIRE(letItGo == L"Let it go, let it go !"_s);
+  }
+
+  {
+    constexpr frozen::wstring letItGo = L"Let it go !";
+    static_assert(letItGo == L"Let it go !",   "frozen::wstring constexpr");
+    static_assert(letItGo == L"Let it go !"_s, "frozen::wstring constexpr literal");
+  }
+}
+
+TEST_CASE("Various u16string operation", "[string]") {
+  {
+    frozen::u16string letItGo = u"Let it go !";
+    REQUIRE(letItGo == u"Let it go !");
+    REQUIRE(letItGo == u"Let it go !"_s);
+
+    letItGo = u"Let it go, let it go !";
+    REQUIRE(letItGo == u"Let it go, let it go !");
+    REQUIRE(letItGo == u"Let it go, let it go !"_s);
+  }
+
+  {
+    constexpr frozen::u16string letItGo = u"Let it go !";
+    static_assert(letItGo == u"Let it go !",   "frozen::u16string constexpr");
+    static_assert(letItGo == u"Let it go !"_s, "frozen::u16string constexpr literal");
+  }
+}
+
+TEST_CASE("Various u32string operation", "[string]") {
+  {
+    frozen::u32string letItGo = U"Let it go !";
+    REQUIRE(letItGo == U"Let it go !");
+    REQUIRE(letItGo == U"Let it go !"_s);
+
+    letItGo = U"Let it go, let it go !";
+    REQUIRE(letItGo == U"Let it go, let it go !");
+    REQUIRE(letItGo == U"Let it go, let it go !"_s);
+  }
+
+  {
+    constexpr frozen::u32string letItGo = U"Let it go !";
+    static_assert(letItGo == U"Let it go !",   "frozen::u32string constexpr");
+    static_assert(letItGo == U"Let it go !"_s, "frozen::u32string constexpr literal");
+  }
+}
+
+#ifdef __cpp_char8_t
+TEST_CASE("Various u8string operation", "[string]") {
+  {
+    frozen::u8string letItGo = u8"Let it go !";
+    REQUIRE(letItGo == u8"Let it go !");
+    REQUIRE(letItGo == u8"Let it go !"_s);
+
+    letItGo = u8"Let it go, let it go !";
+    REQUIRE(letItGo == u8"Let it go, let it go !");
+    REQUIRE(letItGo == u8"Let it go, let it go !"_s);
+  }
+
+  {
+    constexpr frozen::u8string letItGo = u8"Let it go !";
+    static_assert(letItGo == u8"Let it go !",   "frozen::u8string constexpr");
+    static_assert(letItGo == u8"Let it go !"_s, "frozen::u8string constexpr literal");
+  }
+}
+#endif
+
 TEST_CASE("Knuth-Morris-Pratt str search", "[str-search]") {
 
   {
@@ -83,4 +157,3 @@ TEST_CASE("Boyer-Moore str search", "[str-search]") {
   }
 
 }
-


### PR DESCRIPTION
This is an extension of `frozen::string` to support wide strings.
I simply moved the default `frozen::string` to a templated class called `frozen::basic_string` and used it to define `frozen::string` (`frozen::basic_string<char>`) and `frozen::wstring` (`frozen::basic_string<wchar_t>`).
I also added the `_ws` string literal for `frozen::wstring`s.