### PR TITLE
Fix MSVC compiler warning C4245 in pmh.h

### DIFF
--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -28,6 +28,7 @@
 #include "frozen/bits/basic_types.h"
 
 #include <array>
+#include <limits>
 
 namespace frozen {
 
@@ -130,7 +131,7 @@ struct seed_or_index {
   using value_type = uint64_t;
 
 private:
-  static constexpr value_type MINUS_ONE = -1;
+  static constexpr value_type MINUS_ONE = std::numeric_limits<value_type>::max();
   static constexpr value_type HIGH_BIT = ~(MINUS_ONE >> 1);
 
   value_type value_ = 0;
@@ -182,7 +183,7 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const carray<Item, N> &
   carray<seed_or_index, M> G; // Default constructed to "index 0"
 
   // H becomes the second hash table in the resulting pmh function
-  constexpr std::size_t UNUSED = -1;
+  constexpr std::size_t UNUSED = std::numeric_limits<std::size_t>::max();
   carray<std::size_t, M> H;
   H.fill(UNUSED);
 


### PR DESCRIPTION
Fixes signed/unsigned type mismatch warning issued by MSVC in /W4: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4245?view=vs-2019 .

Despite the project's tests not being compiled with /W4 users of the this library will still see this warning if they compile their code with warning level 4 and make use of e.g. `frozen::unordered_map`.

Note that the `<limits>` header I introduced has already been included through `"frozen/bits/algorithms.h"`, I therefore suspect compile time penalty to be minimal, but prefer its use over `auto x = size_t(-1)`.