### PR TITLE
#105 Add non-const functions to map and unordered_map that allow value modification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,16 @@ Frozen
 .. image:: https://travis-ci.org/serge-sans-paille/frozen.svg?branch=master
    :target: https://travis-ci.org/serge-sans-paille/frozen
 
-Header-only library that provides 0 cost initialization for immutable containers and various algorithms.
+Header-only library that provides 0 cost initialization for immutable containers, fixed-size containers, and various algorithms.
 
 Frozen provides:
 
 - immutable (a.k.a. frozen), ``constexpr``-compatible versions of ``std::set``,
   ``std::unordered_set``, ``std::map`` and ``std::unordered_map``.
+  
+- fixed-capacity, ``constinit``-compatible versions of ``std::map`` and 
+  ``std::unordered_map`` with immutable, compile-time selected keys mapped
+  to mutable values.
 
 - 0-cost initialization version of ``std::search`` for frozen needles using
   Boyer-Moore or Knuth-Morris-Pratt algorithms.
@@ -18,8 +22,9 @@ Frozen provides:
 The ``unordered_*`` containers are guaranteed *perfect* (a.k.a. no hash
 collision) and the extra storage is linear with respect to the number of keys.
 
-Once initialized, the containers cannot be updated, and in exchange, lookups
-are faster. And initialization is free when ``constexpr`` is used :-).
+Once initialized, the container keys cannot be updated, and in exchange, lookups
+are faster. And initialization is free when ``constexpr`` or ``constinit`` is 
+used :-).
 
 
 Installation
@@ -87,6 +92,26 @@ String support is built-in:
         {"31", 31},
     };
     constexpr auto val = olaf.at("19");
+
+The associative containers have different functionality with and without ``constexpr``. 
+With ``constexpr``, frozen maps have immutable keys and values. Without ``constexpr``, the 
+vales can be updated in runtime (the keys, however, remain immutable):
+
+.. code:: C++
+
+
+    #include <frozen/unordered_map.h>
+    #include <frozen/string.h>
+
+    static constinit frozen::unordered_map<frozen::string, frozen::string, 2> voice = {
+        {"Anna", "???"},
+        {"Elsa", "???"}
+    };
+    
+    int main() {
+    	voice.at("Anna") = "Kristen";
+	voice.at("Elsa") = "Idina";
+    }
 
 You may also prefer a slightly more DRY initialization syntax:
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(frozen.examples.srcs enum_to_string enum_to_string_hash pixel_art static_assert)
+set(frozen.examples.srcs enum_to_string enum_to_string_hash pixel_art static_assert value_modification)
 
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang")
     list(APPEND frozen.examples.srcs html_entities_map)

--- a/examples/value_modification.cpp
+++ b/examples/value_modification.cpp
@@ -1,0 +1,28 @@
+#include <frozen/set.h>
+#include <frozen/string.h>
+#include <frozen/unordered_map.h>
+#include <iostream>
+
+
+int main() {
+  frozen::unordered_map<frozen::string, int, 2> fruits = {
+      {"n_apples", 0},
+      {"n_pears", 0},
+  };
+
+  std::cout << fruits.at("n_apples") << std::endl;
+  std::cout << fruits.at("n_pears") << std::endl;
+
+  fruits.at("n_apples") = 10;
+  fruits.at("n_pears") = fruits.at("n_apples") * 2;
+
+  std::cout << fruits.at("n_apples") << std::endl;
+  std::cout << fruits.at("n_pears") << std::endl;
+
+  auto found = fruits.find("n_oranges");
+  if (found == fruits.end()) {
+    std::cout << "no oranges, as expected" << std::endl;
+  }
+
+  auto range = fruits.equal_range("n_oranges");
+}

--- a/examples/value_modification.cpp
+++ b/examples/value_modification.cpp
@@ -5,24 +5,25 @@
 
 
 int main() {
+  // To make a frozen::unordered_map where you can modify the values, make a
+  // non-constexpr instance:
   frozen::unordered_map<frozen::string, int, 2> fruits = {
       {"n_apples", 0},
       {"n_pears", 0},
   };
 
-  std::cout << fruits.at("n_apples") << std::endl;
-  std::cout << fruits.at("n_pears") << std::endl;
-
+  // You can update the values:
   fruits.at("n_apples") = 10;
   fruits.at("n_pears") = fruits.at("n_apples") * 2;
-
   std::cout << fruits.at("n_apples") << std::endl;
   std::cout << fruits.at("n_pears") << std::endl;
 
+  // Find also works
   auto found = fruits.find("n_oranges");
   if (found == fruits.end()) {
     std::cout << "no oranges, as expected" << std::endl;
   }
 
-  auto range = fruits.equal_range("n_oranges");
+  // Range also works
+  auto range = fruits.equal_range("n_apples");
 }

--- a/examples/value_modification.cpp
+++ b/examples/value_modification.cpp
@@ -3,27 +3,35 @@
 #include <frozen/unordered_map.h>
 #include <iostream>
 
+/// MAYBE_CONSTINIT expands to `constinit` if available.
+#if __cpp_constinit
+#define MAYBE_CONSTINIT constinit
+#else
+#define MAYBE_CONSTINIT
+#endif
+
+// To make a frozen::unordered_map where you can modify the values, make a
+// non-constexpr instance. If available, prefer to use constinit. It will
+// initialize the map during compilation and detect any exceptions.
+MAYBE_CONSTINIT static frozen::unordered_map<frozen::string, int, 2> fruits = {
+    {"n_apples", 0},
+    {"n_pears", 0},
+};
 
 int main() {
-  // To make a frozen::unordered_map where you can modify the values, make a
-  // non-constexpr instance:
-  frozen::unordered_map<frozen::string, int, 2> fruits = {
-      {"n_apples", 0},
-      {"n_pears", 0},
-  };
-
-  // You can update the values:
+  // Update the values using at()
   fruits.at("n_apples") = 10;
   fruits.at("n_pears") = fruits.at("n_apples") * 2;
-  std::cout << fruits.at("n_apples") << std::endl;
-  std::cout << fruits.at("n_pears") << std::endl;
+  std::cout << "n_apples: " << fruits.at("n_apples") << std::endl;
+  std::cout << "n_pears: " << fruits.at("n_pears") << std::endl;
 
-  // Find also works
-  auto found = fruits.find("n_oranges");
-  if (found == fruits.end()) {
-    std::cout << "no oranges, as expected" << std::endl;
-  }
+  // You can also update values via the iterator returned by find()
+  auto found = fruits.find("n_apples");
+  found->second = 0;
+  std::cout << "n_apples: " << fruits.at("n_apples") << std::endl;
 
   // Range also works
   auto range = fruits.equal_range("n_apples");
+  range.first->second = 1337;
+  std::cout << "n_apples: " << fruits.at("n_apples") << std::endl;
 }

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -178,12 +178,8 @@ public:
   constexpr key_compare value_comp() const { return less_than_; }
 
  private:
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr auto find_impl(This& self, Key const &key) {
+  static constexpr auto find_impl(This&& self, Key const &key) {
     auto where = self.lower_bound(key);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where;
@@ -191,12 +187,8 @@ public:
       return self.end();
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr auto equal_range_impl(This& self, Key const &key) {
+  static constexpr auto equal_range_impl(This&& self, Key const &key) {
     auto lower = self.lower_bound(key);
     using lower_t = decltype(lower);
     if (lower == self.end())
@@ -205,12 +197,8 @@ public:
       return std::pair<lower_t, lower_t>{lower, lower + 1};
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr const_iterator lower_bound_impl(This& self, Key const &key) {
+  static constexpr const_iterator lower_bound_impl(This&& self, Key const &key) {
     auto const where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where;
@@ -218,12 +206,8 @@ public:
       return self.end();
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr const_iterator upper_bound_impl(This& self, Key const &key) {
+  static constexpr const_iterator upper_bound_impl(This&& self, Key const &key) {
     auto const where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where + 1;

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -146,9 +146,8 @@ public:
   constexpr key_equal key_eq() const { return equal_; }
 
 private:
-
   template <class This>
-  static constexpr auto& at_impl(This&& self, Key const &key) {
+  static inline constexpr auto& at_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     if (self.equal_(kv.first, key))
       return kv.second;
@@ -157,7 +156,7 @@ private:
   }
 
   template <class This>
-  static constexpr auto find_impl(This&& self, Key const &key) {
+  static inline constexpr auto find_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     if (self.equal_(kv.first, key))
       return &kv;
@@ -166,7 +165,7 @@ private:
   }
 
   template <class This>
-  static constexpr auto equal_range_impl(This&& self, Key const &key) {
+  static inline constexpr auto equal_range_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     using kv_ptr = decltype(&kv);
     if (self.equal_(kv.first, key))
@@ -176,7 +175,7 @@ private:
   }
 
   template <class This>
-  static constexpr auto& lookup_impl(This&& self, Key const &key) {
+  static inline constexpr auto& lookup_impl(This&& self, Key const &key) {
     return self.items_[self.tables_.lookup(key)];
   }
 

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -146,12 +146,9 @@ public:
   constexpr key_equal key_eq() const { return equal_; }
 
 private:
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
+
   template <class This>
-  static constexpr auto& at_impl(This& self, Key const &key) {
+  static constexpr auto& at_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     if (self.equal_(kv.first, key))
       return kv.second;
@@ -159,12 +156,8 @@ private:
       FROZEN_THROW_OR_ABORT(std::out_of_range("unknown key"));
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr auto find_impl(This& self, Key const &key) {
+  static constexpr auto find_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     if (self.equal_(kv.first, key))
       return &kv;
@@ -172,12 +165,8 @@ private:
       return self.items_.end();
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr auto equal_range_impl(This& self, Key const &key) {
+  static constexpr auto equal_range_impl(This&& self, Key const &key) {
     auto& kv = self.lookup(key);
     using kv_ptr = decltype(&kv);
     if (self.equal_(kv.first, key))
@@ -186,12 +175,8 @@ private:
       return std::pair<kv_ptr, kv_ptr>{self.items_.end(), self.items_.end()};
   }
 
-  /*
-   * Template used to reduce code duplication between const and non-const
-   * functions. https://stackoverflow.com/a/62215403/4832300
-   */
   template <class This>
-  static constexpr auto& lookup_impl(This& self, Key const &key) {
+  static constexpr auto& lookup_impl(This&& self, Key const &key) {
     return self.items_[self.tables_.lookup(key)];
   }
 

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -285,7 +285,6 @@ TEST_CASE("frozen::map <> frozen::make_map", "[map]") {
   }
 }
 
-
 TEST_CASE("frozen::map constexpr", "[map]") {
   constexpr frozen::map<unsigned, unsigned, 2> ce = {{3,4}, {11,12}};
   static_assert(*ce.begin() == std::pair<unsigned, unsigned>{3,4}, "");
@@ -294,4 +293,47 @@ TEST_CASE("frozen::map constexpr", "[map]") {
   static_assert(ce.count(3), "");
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
+}
+
+TEST_CASE("Modifiable frozen::map", "[map]") {
+  frozen::map<int, int, 3> frozen_map = {{0, 1}, {2, 3}, {4, 5}};
+
+  SECTION("Lookup existing values") {
+    REQUIRE(frozen_map.at(0) == 1);
+    REQUIRE(frozen_map.find(0)->second == 1);
+    REQUIRE(frozen_map.equal_range(0).first->second == 1);
+
+    REQUIRE(frozen_map.at(2) == 3);
+    REQUIRE(frozen_map.find(2)->second == 3);
+    REQUIRE(frozen_map.equal_range(2).first->second == 3);
+
+    REQUIRE(frozen_map.at(4) == 5);
+    REQUIRE(frozen_map.find(4)->second == 5);
+    REQUIRE(frozen_map.equal_range(4).first->second == 5);
+  }
+
+  SECTION("Lookup failure") {
+    REQUIRE(frozen_map.find(5) == frozen_map.end());
+    REQUIRE_THROWS_AS(frozen_map.at(5), std::out_of_range);
+  }
+
+  SECTION("Modify value") {
+    frozen_map.at(0) = -1;
+    REQUIRE(frozen_map.at(0) == -1);
+
+    frozen_map.begin()->second = -2;
+    REQUIRE(frozen_map.begin()->second == -2);
+
+    (frozen_map.end() - 1)->second = -3;
+    REQUIRE((frozen_map.end() - 1)->second == -3);
+
+    frozen_map.equal_range(4).first->second = -5;
+    REQUIRE(frozen_map.at(4) == -5);
+
+    frozen_map.lower_bound(2)->second = -22;
+    REQUIRE(frozen_map.at(2) == -22);
+
+    frozen_map.upper_bound(2)->second = -33;
+    REQUIRE(frozen_map.at(4) == -33);
+  }
 }

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -182,3 +182,40 @@ TEST_CASE("access", "[unordered_map]") {
   REQUIRE(4 == ce.at(3));
   REQUIRE_THROWS(ce.at(33));
 }
+
+TEST_CASE("Modifiable frozen::unordered_map", "[unordered_map]") {
+  frozen::unordered_map<int, int, 3> frozen_map = {{0, 1}, {2, 3}, {4, 5}};
+
+  SECTION("Lookup existing values") {
+    REQUIRE(frozen_map.at(0) == 1);
+    REQUIRE(frozen_map.find(0)->second == 1);
+    REQUIRE(frozen_map.equal_range(0).first->second == 1);
+
+    REQUIRE(frozen_map.at(2) == 3);
+    REQUIRE(frozen_map.find(2)->second == 3);
+    REQUIRE(frozen_map.equal_range(2).first->second == 3);
+
+    REQUIRE(frozen_map.at(4) == 5);
+    REQUIRE(frozen_map.find(4)->second == 5);
+    REQUIRE(frozen_map.equal_range(4).first->second == 5);
+  }
+
+  SECTION("Lookup failure") {
+    REQUIRE(frozen_map.find(5) == frozen_map.end());
+    REQUIRE_THROWS_AS(frozen_map.at(5), std::out_of_range);
+  }
+
+  SECTION("Modify value") {
+    frozen_map.at(0) = -1;
+    REQUIRE(frozen_map.at(0) == -1);
+
+    frozen_map.begin()->second = -2;
+    REQUIRE(frozen_map.begin()->second == -2);
+
+    (frozen_map.end() - 1)->second = -3;
+    REQUIRE((frozen_map.end() - 1)->second == -3);
+
+    frozen_map.equal_range(4).first->second = -5;
+    REQUIRE(frozen_map.at(4) == -5);
+  }
+}


### PR DESCRIPTION
As discussed in #105, this library could support `map`s and `unordered_map`s where the keys are immutable and chosen at compile time, but the values are mutable.

This PR accomplishes this by adding non-const implementations of functions in `map` and `unordered_map`.

To avoid code duplication, I made template functions that the const and non-const functions can call to. By doing this, the compiler can generate the const and non-const implementation from one template.

Additional tests, documentation, and examples should be added with this PR, but I was hoping to get some implementation feedback for now.