### PR TITLE
Allow make_set<frozen::string> to work with an initializer of string literals

### DIFF
--- a/include/frozen/set.h
+++ b/include/frozen/set.h
@@ -209,11 +209,18 @@ constexpr auto make_set(bits::ignored_arg = {}/* for consistency with the initia
   return set<T, 0>{};
 }
 
-template <typename T, std::size_t N>
-constexpr auto make_set(const T (&args)[N]) {
-  return set<T, N>(args);
+namespace detail {
+  template <typename T, typename U, std::size_t N, std::size_t... I>
+  constexpr auto make_set_helper(const U (&args)[N], std::index_sequence<I...>) {
+    T args_t[N] = { T{args[I]}... };
+    return frozen::set<T, N>(args_t);
+  }
 }
 
+template <typename T, std::size_t N, typename U = T>
+constexpr auto make_set(const U (&args)[N]) {
+    return detail::make_set_helper<T>(args, std::make_index_sequence<N>{});
+}
 
 } // namespace frozen
 

--- a/tests/test_str_set.cpp
+++ b/tests/test_str_set.cpp
@@ -43,6 +43,42 @@ TEST_CASE("tripleton int frozen ordered set", "[set]") {
   std::for_each(ze_set.begin(), ze_set.end(), [](frozen::string const &) {});
 }
 
+TEST_CASE("tripleton int frozen ordered set from make_set", "[set]") {
+  constexpr auto ze_set = frozen::make_set<frozen::string>({"1", "2", "3"});
+
+  constexpr auto empty = ze_set.empty();
+  REQUIRE(!empty);
+
+  constexpr auto size = ze_set.size();
+  REQUIRE(size == 3);
+
+  constexpr auto max_size = ze_set.max_size();
+  REQUIRE(max_size == 3);
+
+  constexpr auto nocount = ze_set.count("4");
+  REQUIRE(nocount == 0);
+
+  constexpr auto count = ze_set.count("1");
+  REQUIRE(count == 1);
+
+  auto notfound = ze_set.find("4");
+  REQUIRE(notfound == ze_set.end());
+
+  auto found = ze_set.find("1");
+  REQUIRE(found == ze_set.begin());
+
+  auto range = ze_set.equal_range("1");
+  REQUIRE(std::get<0>(range) != ze_set.end());
+
+  auto begin = ze_set.begin(), end = ze_set.end();
+  REQUIRE(begin != end);
+
+  auto cbegin = ze_set.cbegin(), cend = ze_set.cend();
+  REQUIRE(cbegin != cend);
+
+  std::for_each(ze_set.begin(), ze_set.end(), [](frozen::string const &) {});
+}
+
 TEST_CASE("frozen::set<str> <> std::set",
           "[set]") {
 #define INIT_SEQ                                                               \


### PR DESCRIPTION
`make_set<frozen::string>()` is useful because it deduces the number of elements in the initializer list. However, gcc (at least 7.x and 8.x) do not allow it to be used with string literals as input. For example:

```
#include <frozen/set.h>
#include <frozen/string.h>
constexpr auto s = frozen::make_set<frozen::string>({ "a", "b", "c" });
```

This fails to compile (g++ 7.5.0) with the following errors:

```
ff.cc:4:70: error: no matching function for call to ‘make_set<frozen::string>(<brace-enclosed initializer list>)’
 constexpr auto s = frozen::make_set<frozen::string>({ "a", "b", "c" });
                                                                      ^
In file included from ff.cc:2:0:
include/frozen/set.h:208:16: note: candidate: template<class T> constexpr auto frozen::make_set(frozen::bits::ignored_arg)
 constexpr auto make_set(bits::ignored_arg = {}/* for consistency with the initializer below for N = 0*/) {
                ^~~~~~~~
include/frozen/set.h:208:16: note:   template argument deduction/substitution failed:
ff.cc:4:70: note:   cannot convert ‘{"a", "b", "c"}’ (type ‘<brace-enclosed initializer list>’) to type ‘frozen::bits::ignored_arg’
 constexpr auto s = frozen::make_set<frozen::string>({ "a", "b", "c" });
                                                                      ^
In file included from ff.cc:2:0:
include/frozen/set.h:213:16: note: candidate: template<class T, long unsigned int N> constexpr auto frozen::make_set(const T (&)[N])
 constexpr auto make_set(const T (&args)[N]) {
                ^~~~~~~~
include/frozen/set.h:213:16: note:   template argument deduction/substitution failed:
ff.cc:4:70: note:   mismatched types ‘frozen::basic_string<char>’ and ‘const char*’
 constexpr auto s = frozen::make_set<frozen::string>({ "a", "b", "c" });
```

I *think* this is right, since in the deduction of the array type initializer, `T` must exactly match the desired type `frozen::string`. Surprisingly to me, clang allows this without issue.

This branch fixes that by adding a third template parameter `U` that is deduced from the actual input array. This array is then used to initialize a new array of type `T`, which is then used to construct the `set`.