### PR TITLE
Add support for "transparent" comparators to map

### DIFF
--- a/include/frozen/bits/type_traits.h
+++ b/include/frozen/bits/type_traits.h
@@ -1,0 +1,50 @@
+/*
+ * Frozen
+ * Copyright 2016 QuarksLab
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_BITS_TYPE_TRAITS_H
+#define FROZEN_LETITGO_BITS_TYPE_TRAITS_H
+
+#include <type_traits>
+
+namespace frozen {
+
+namespace bits {
+
+template <class...>
+using void_t = void;
+
+template <class, class, class = void_t<>>
+struct has_is_transparent
+{};
+template <class T, class U>
+struct has_is_transparent<T, U, void_t<typename T::is_transparent>>
+{
+  typedef void type;
+};
+
+template <class T, class U>
+using has_is_transparent_t = typename has_is_transparent<T, U>::type;
+
+} // namespace bits
+} // namespace frozen
+
+#endif

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -27,6 +27,7 @@
 #include "frozen/bits/basic_types.h"
 #include "frozen/bits/constexpr_assert.h"
 #include "frozen/bits/exceptions.h"
+#include "frozen/bits/type_traits.h"
 #include "frozen/bits/version.h"
 
 #include <utility>
@@ -48,10 +49,22 @@ public:
                            std::pair<Key, Value> const &other) const {
     return comparator_(std::get<0>(self), std::get<0>(other));
   }
+  template <class Key1, class Key2, class Value,
+            typename = bits::has_is_transparent_t<Comparator, Key1>>
+  constexpr int operator()(std::pair<Key1, Value> const &self,
+                           std::pair<Key2, Value> const &other) const {
+    return comparator_(std::get<0>(self), std::get<0>(other));
+  }
 
   template <class Key, class Value>
   constexpr int operator()(Key const &self_key,
                            std::pair<Key, Value> const &other) const {
+    return comparator_(self_key, std::get<0>(other));
+  }
+  template <class Key1, class Key2, class Value,
+            typename = bits::has_is_transparent_t<Comparator, Key1>>
+  constexpr int operator()(Key1 const &self_key,
+                           std::pair<Key2, Value> const &other) const {
     return comparator_(self_key, std::get<0>(other));
   }
 
@@ -60,9 +73,20 @@ public:
                            Key const &other_key) const {
     return comparator_(std::get<0>(self), other_key);
   }
+  template <class Key1, class Key2, class Value,
+            typename = bits::has_is_transparent_t<Comparator, Key1>>
+  constexpr int operator()(std::pair<Key1, Value> const &self,
+                           Key2 const &other_key) const {
+    return comparator_(std::get<0>(self), other_key);
+  }
 
   template <class Key>
   constexpr int operator()(Key const &self_key, Key const &other_key) const {
+    return comparator_(self_key, other_key);
+  }
+  template <class Key1, class Key2,
+            typename = bits::has_is_transparent_t<Comparator, Key1>>
+  constexpr int operator()(Key1 const &self_key, Key2 const &other_key) const {
     return comparator_(self_key, other_key);
   }
 };
@@ -142,12 +166,27 @@ public:
   constexpr std::size_t count(Key const &key) const {
     return bits::binary_search<N>(items_.begin(), key, less_than_);
   }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::size_t count(K const &key) const {
+    return bits::binary_search<N>(items_.begin(), key, less_than_);
+  }
 
   constexpr const_iterator find(Key const &key) const {
     return find_impl(*this, key);
   }
   constexpr iterator find(Key const &key) {
     return find_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator find(K const &key) const {
+    return map::find_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator find(K const &key) {
+    return map::find_impl(*this, key);
   }
 
   constexpr std::pair<const_iterator, const_iterator>
@@ -157,11 +196,32 @@ public:
   constexpr std::pair<iterator, iterator> equal_range(Key const &key) {
     return equal_range_impl(*this, key);
   }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::pair<const_iterator, const_iterator>
+  equal_range(K const &key) const {
+    return equal_range_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::pair<iterator, iterator> equal_range(K const &key) {
+    return equal_range_impl(*this, key);
+  }
 
   constexpr const_iterator lower_bound(Key const &key) const {
     return lower_bound_impl(*this, key);
   }
   constexpr iterator lower_bound(Key const &key) {
+    return lower_bound_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator lower_bound(K const &key) const {
+    return lower_bound_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator lower_bound(K const &key) {
     return lower_bound_impl(*this, key);
   }
 
@@ -171,14 +231,24 @@ public:
   constexpr iterator upper_bound(Key const &key) {
     return upper_bound_impl(*this, key);
   }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator upper_bound(K const &key) const {
+    return upper_bound_impl(*this, key);
+  }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator upper_bound(K const &key) {
+    return upper_bound_impl(*this, key);
+  }
 
   /* observers */
   constexpr key_compare key_comp() const { return less_than_; }
   constexpr key_compare value_comp() const { return less_than_; }
 
  private:
-  template <class This>
-  static inline constexpr auto& at_impl(This&& self, Key const &key) {
+  template <class This, class K>
+  static inline constexpr auto& at_impl(This&& self, K const &key) {
     auto where = self.lower_bound(key);
     if (where != self.end())
       return where->second;
@@ -186,8 +256,8 @@ public:
       FROZEN_THROW_OR_ABORT(std::out_of_range("unknown key"));
   }
 
-  template <class This>
-  static inline constexpr auto find_impl(This&& self, Key const &key) {
+  template <class This, class K>
+  static inline constexpr auto find_impl(This&& self, K const &key) {
     auto where = self.lower_bound(key);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where;
@@ -195,8 +265,8 @@ public:
       return self.end();
   }
 
-  template <class This>
-  static inline constexpr auto equal_range_impl(This&& self, Key const &key) {
+  template <class This, class K>
+  static inline constexpr auto equal_range_impl(This&& self, K const &key) {
     auto lower = self.lower_bound(key);
     using lower_t = decltype(lower);
     if (lower == self.end())
@@ -205,8 +275,8 @@ public:
       return std::pair<lower_t, lower_t>{lower, lower + 1};
   }
 
-  template <class This>
-  static inline constexpr auto lower_bound_impl(This&& self, Key const &key) -> decltype(self.end()) {
+  template <class This, class K>
+  static inline constexpr auto lower_bound_impl(This&& self, K const &key) -> decltype(self.end()) {
     auto where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where;
@@ -214,8 +284,8 @@ public:
       return self.end();
   }
 
-  template <class This>
-  static inline constexpr auto upper_bound_impl(This&& self, Key const &key) -> decltype(self.end()) {
+  template <class This, class K>
+  static inline constexpr auto upper_bound_impl(This&& self, K const &key) -> decltype(self.end()) {
     auto where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
     if ((where != self.end()) && !self.less_than_(key, *where))
       return where + 1;
@@ -284,33 +354,58 @@ public:
   /* lookup */
 
   constexpr std::size_t count(Key const &) const { return 0; }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::size_t count(K const &) const { return 0; }
 
   constexpr const_iterator find(Key const &) const { return end(); }
   constexpr iterator find(Key const &) { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator find(K const &) const { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator find(K const &) { return end(); }
 
   constexpr std::pair<const_iterator, const_iterator>
-  equal_range(Key const &) const {
-    return {end(), end()};
-  }
+  equal_range(Key const &) const { return {end(), end()}; }
   constexpr std::pair<iterator, iterator>
-  equal_range(Key const &) {
-    return {end(), end()};
-  }
+  equal_range(Key const &) { return {end(), end()}; }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::pair<const_iterator, const_iterator>
+  equal_range(K const &) const { return {end(), end()}; }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr std::pair<iterator, iterator>
+  equal_range(K const &) { return {end(), end()}; }
 
   constexpr const_iterator lower_bound(Key const &) const { return end(); }
   constexpr iterator lower_bound(Key const &) { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator lower_bound(K const &) const { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator lower_bound(K const &) { return end(); }
 
   constexpr const_iterator upper_bound(Key const &) const { return end(); }
   constexpr iterator upper_bound(Key const &) { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr const_iterator upper_bound(K const &) const { return end(); }
+  template <class K,
+            typename = bits::has_is_transparent_t<Compare, K>>
+  constexpr iterator upper_bound(K const &) { return end(); }
 
   /* observers */
   constexpr key_compare key_comp() const { return less_than_; }
   constexpr key_compare value_comp() const { return less_than_; }
 };
 
-template <typename T, typename U>
+template <typename T, typename U, typename Compare = std::less<T>>
 constexpr auto make_map(bits::ignored_arg = {}/* for consistency with the initializer below for N = 0*/) {
-  return map<T, U, 0>{};
+  return map<T, U, 0, Compare>{};
 }
 
 template <typename T, typename U, std::size_t N>
@@ -321,6 +416,16 @@ constexpr auto make_map(std::pair<T, U> const (&items)[N]) {
 template <typename T, typename U, std::size_t N>
 constexpr auto make_map(std::array<std::pair<T, U>, N> const &items) {
   return map<T, U, N>{items};
+}
+
+template <typename T, typename U, typename Compare, std::size_t N>
+constexpr auto make_map(std::pair<T, U> const (&items)[N]) {
+  return map<T, U, N, Compare>{items};
+}
+
+template <typename T, typename U, typename Compare, std::size_t N>
+constexpr auto make_map(std::array<std::pair<T, U>, N> const &items) {
+  return map<T, U, N, Compare>{items};
 }
 
 } // namespace frozen

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -7,14 +7,6 @@
 #include "bench.hpp"
 #include "catch.hpp"
 
-struct S {
-  int x;
-};
-constexpr inline bool operator==(S const &a, S const &b) { return a.x == b.x; }
-constexpr inline bool operator<(S const &a, S const &b) { return a.x < b.x; }
-constexpr inline bool operator<(S const &a, int b) { return a.x < b; }
-constexpr inline bool operator<(int a, S const &b) { return a < b.x; }
-
 TEST_CASE("empty frozen map", "[map]") {
   constexpr frozen::map<int, float, 0> ze_map{};
 
@@ -61,26 +53,6 @@ TEST_CASE("empty frozen map", "[map]") {
   REQUIRE(std::distance(ze_map.rbegin(), ze_map.rend()) == 0);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
                      decltype(ze_map)::value_type(3, 5.3f)) == 0);
-}
-
-TEST_CASE("empty frozen transparent map", "[map]") {
-  constexpr frozen::map<S, bool, 0, std::less<void>> ze_map{};
-
-  constexpr auto count = ze_map.count(3);
-  REQUIRE(count == 0);
-
-  constexpr auto find = ze_map.find(5);
-  REQUIRE(find == ze_map.end());
-
-  constexpr auto range = ze_map.equal_range(0);
-  REQUIRE(std::get<0>(range) == ze_map.end());
-  REQUIRE(std::get<1>(range) == ze_map.end());
-
-  constexpr auto lower_bound = ze_map.lower_bound(1);
-  REQUIRE(lower_bound == ze_map.end());
-
-  constexpr auto upper_bound = ze_map.upper_bound(1);
-  REQUIRE(upper_bound == ze_map.end());
 }
 
 TEST_CASE("singleton frozen map", "[map]") {
@@ -368,6 +340,34 @@ TEST_CASE("Modifiable frozen::map", "[map]") {
     frozen_map.upper_bound(2)->second = -33;
     REQUIRE(frozen_map.at(4) == -33);
   }
+}
+
+struct S {
+  int x;
+};
+constexpr inline bool operator==(S const &a, S const &b) { return a.x == b.x; }
+constexpr inline bool operator<(S const &a, S const &b) { return a.x < b.x; }
+constexpr inline bool operator<(S const &a, int b) { return a.x < b; }
+constexpr inline bool operator<(int a, S const &b) { return a < b.x; }
+
+TEST_CASE("empty frozen transparent map", "[map]") {
+  constexpr frozen::map<S, bool, 0, std::less<void>> ze_map{};
+
+  constexpr auto count = ze_map.count(3);
+  REQUIRE(count == 0);
+
+  constexpr auto find = ze_map.find(5);
+  REQUIRE(find == ze_map.end());
+
+  constexpr auto range = ze_map.equal_range(0);
+  REQUIRE(std::get<0>(range) == ze_map.end());
+  REQUIRE(std::get<1>(range) == ze_map.end());
+
+  constexpr auto lower_bound = ze_map.lower_bound(1);
+  REQUIRE(lower_bound == ze_map.end());
+
+  constexpr auto upper_bound = ze_map.upper_bound(1);
+  REQUIRE(upper_bound == ze_map.end());
 }
 
 TEST_CASE("frozen transparent map", "[map]") {

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -1,10 +1,21 @@
 #include <algorithm>
 #include <frozen/map.h>
+#include <functional>
 #include <iostream>
 #include <map>
 
 #include "bench.hpp"
 #include "catch.hpp"
+
+struct S {
+  int x;
+};
+constexpr inline bool operator==(S const &a, S const &b) { return a.x == b.x; }
+constexpr inline bool operator==(S const &a, int b) { return a.x == b; }
+constexpr inline bool operator==(int a, S const &b) { return a == b.x; }
+constexpr inline bool operator<(S const &a, S const &b) { return a.x < b.x; }
+constexpr inline bool operator<(S const &a, int b) { return a.x < b; }
+constexpr inline bool operator<(int a, S const &b) { return a < b.x; }
 
 TEST_CASE("empty frozen map", "[map]") {
   constexpr frozen::map<int, float, 0> ze_map{};
@@ -52,6 +63,26 @@ TEST_CASE("empty frozen map", "[map]") {
   REQUIRE(std::distance(ze_map.rbegin(), ze_map.rend()) == 0);
   REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
                      decltype(ze_map)::value_type(3, 5.3f)) == 0);
+}
+
+TEST_CASE("empty frozen transparent map", "[map]") {
+  constexpr frozen::map<S, bool, 0, std::less<void>> ze_map{};
+
+  constexpr auto count = ze_map.count(3);
+  REQUIRE(count == 0);
+
+  constexpr auto find = ze_map.find(5);
+  REQUIRE(find == ze_map.end());
+
+  constexpr auto range = ze_map.equal_range(0);
+  REQUIRE(std::get<0>(range) == ze_map.end());
+  REQUIRE(std::get<1>(range) == ze_map.end());
+
+  constexpr auto lower_bound = ze_map.lower_bound(1);
+  REQUIRE(lower_bound == ze_map.end());
+
+  constexpr auto upper_bound = ze_map.upper_bound(1);
+  REQUIRE(upper_bound == ze_map.end());
 }
 
 TEST_CASE("singleton frozen map", "[map]") {
@@ -338,5 +369,115 @@ TEST_CASE("Modifiable frozen::map", "[map]") {
 
     frozen_map.upper_bound(2)->second = -33;
     REQUIRE(frozen_map.at(4) == -33);
+  }
+}
+
+TEST_CASE("froze transparent map", "[map]") {
+  constexpr frozen::map<S, bool, 4, std::less<void>> ze_map{
+      {S{10}, true}, {S{20}, false}, {S{30}, true}, {S{40}, false}};
+
+  constexpr auto empty = ze_map.empty();
+  REQUIRE(!empty);
+
+  constexpr auto size = ze_map.size();
+  REQUIRE(size == 4);
+
+  constexpr auto max_size = ze_map.max_size();
+  REQUIRE(max_size == 4);
+
+  constexpr auto count1 = ze_map.count(1);
+  REQUIRE(count1 == 0);
+
+  constexpr auto count10 = ze_map.count(10);
+  REQUIRE(count10 == 1);
+
+  const auto find10 = ze_map.find(10);
+  REQUIRE(find10 == ze_map.begin());
+  REQUIRE(std::get<0>(*find10) == S{10});
+  REQUIRE(std::get<1>(*find10) == true);
+
+  const auto find15 = ze_map.find(15);
+  REQUIRE(find15 == ze_map.end());
+
+  const auto range0 = ze_map.equal_range(0);
+  REQUIRE(std::get<0>(range0) == ze_map.end());
+  REQUIRE(std::get<1>(range0) == ze_map.end());
+
+  const auto range1 = ze_map.equal_range(10);
+  REQUIRE(std::get<0>(range1) == ze_map.begin());
+  REQUIRE(std::get<1>(range1) == ze_map.begin() + 1);
+
+  const auto lower_bound0 = ze_map.lower_bound(0);
+  REQUIRE(lower_bound0 == ze_map.end());
+
+  for (auto val : ze_map) {
+    const auto lower_bound = ze_map.lower_bound(std::get<0>(val));
+    REQUIRE(lower_bound == ze_map.find(std::get<0>(val)));
+  }
+
+  const auto lower_bound2 = ze_map.lower_bound(50);
+  REQUIRE(lower_bound2 == ze_map.end());
+
+  const auto upper_bound0 = ze_map.upper_bound(0);
+  REQUIRE(upper_bound0 == ze_map.end());
+
+  const auto upper_bound1 = ze_map.upper_bound(10);
+  REQUIRE(upper_bound1 == (ze_map.begin() + 1));
+
+  const auto upper_bound2 = ze_map.upper_bound(50);
+  REQUIRE(upper_bound2 == ze_map.end());
+
+  auto const begin = ze_map.begin(), end = ze_map.end();
+  REQUIRE((begin + ze_map.size()) == end);
+
+  auto const key_comp = ze_map.key_comp();
+  auto const key_comparison = key_comp(1, 2);
+  REQUIRE(key_comparison);
+
+  auto const value_comp = ze_map.value_comp();
+  auto const value_comparison = value_comp(11, 12);
+  REQUIRE(value_comparison);
+
+  auto const cbegin = ze_map.cbegin(), cend = ze_map.cend();
+  REQUIRE(cbegin == (cend - ze_map.size()));
+
+  std::for_each(ze_map.begin(), ze_map.end(), [](std::tuple<S, bool>) {});
+  REQUIRE((std::size_t)std::distance(ze_map.rbegin(), ze_map.rend()) == ze_map.size());
+  REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
+                     decltype(ze_map)::value_type{S{20}, true}) == 0);
+  REQUIRE(std::count(ze_map.crbegin(), ze_map.crend(),
+                     decltype(ze_map)::value_type{S{20}, false}) == 1);
+}
+
+TEST_CASE("frozen::map <> frozen::make_map transparent", "[map]") {
+  constexpr frozen::map<int, int, 128, std::less<void>> frozen_map = { INIT_SEQ };
+  constexpr auto frozen_map2 = frozen::make_map<int, int, std::less<void>>({INIT_SEQ});
+  constexpr auto frozen_map3 = frozen::make_map<int, int, std::less<void>>(std::array<std::pair<int, int>, 128>{{INIT_SEQ}});
+  REQUIRE(std::equal(frozen_map2.begin(), frozen_map2.end(), frozen_map3.begin()));
+
+  SECTION("checking size and content") {
+    REQUIRE(frozen_map.size() == frozen_map2.size());
+    for (auto v : frozen_map2)
+      REQUIRE(frozen_map.count(std::get<0>(v)));
+    for (auto v : frozen_map)
+      REQUIRE(frozen_map2.count(std::get<0>(v)));
+  }
+
+  constexpr frozen::map<int, short, 0, std::less<void>> frozen_empty_map = {};
+  constexpr auto frozen_empty_map2 = frozen::make_map<int, short, std::less<void>>();
+  constexpr auto frozen_empty_map3 = frozen::make_map<int, short, std::less<void>>({});
+
+  SECTION("checking empty map") {
+    REQUIRE(frozen_empty_map.empty());
+    REQUIRE(frozen_empty_map.size() == 0);
+    REQUIRE(frozen_empty_map.begin() == frozen_empty_map.end());
+
+    REQUIRE(frozen_empty_map2.empty());
+    REQUIRE(frozen_empty_map2.size() == 0);
+    REQUIRE(frozen_empty_map2.begin() == frozen_empty_map2.end());
+
+    REQUIRE(frozen_empty_map3.empty());
+    REQUIRE(frozen_empty_map3.size() == 0);
+    REQUIRE(frozen_empty_map3.begin() == frozen_empty_map3.end());
   }
 }

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -11,8 +11,6 @@ struct S {
   int x;
 };
 constexpr inline bool operator==(S const &a, S const &b) { return a.x == b.x; }
-constexpr inline bool operator==(S const &a, int b) { return a.x == b; }
-constexpr inline bool operator==(int a, S const &b) { return a == b.x; }
 constexpr inline bool operator<(S const &a, S const &b) { return a.x < b.x; }
 constexpr inline bool operator<(S const &a, int b) { return a.x < b; }
 constexpr inline bool operator<(int a, S const &b) { return a < b.x; }
@@ -372,7 +370,7 @@ TEST_CASE("Modifiable frozen::map", "[map]") {
   }
 }
 
-TEST_CASE("froze transparent map", "[map]") {
+TEST_CASE("frozen transparent map", "[map]") {
   constexpr frozen::map<S, bool, 4, std::less<void>> ze_map{
       {S{10}, true}, {S{20}, false}, {S{30}, true}, {S{40}, false}};
 


### PR DESCRIPTION
This PR adds support for "transparent" comparator (like `std::less<void>`) to `frozen::map`.

To keep the PR small (smaller) I'd vote to implement support for transparent comparator to the other containers in separate PRs.