### PR TITLE
Standard implementation for lower_bound/upper_bound/equal_range.

### DIFF
--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -179,7 +179,7 @@ public:
  private:
   template <class This>
   static inline constexpr auto& at_impl(This&& self, Key const &key) {
-    auto where = self.lower_bound(key);
+    auto where = self.find(key);
     if (where != self.end())
       return where->second;
     else
@@ -189,7 +189,7 @@ public:
   template <class This>
   static inline constexpr auto find_impl(This&& self, Key const &key) {
     auto where = self.lower_bound(key);
-    if ((where != self.end()) && !self.less_than_(key, *where))
+    if (where != self.end() && !self.less_than_(key, *where))
       return where;
     else
       return self.end();
@@ -199,28 +199,24 @@ public:
   static inline constexpr auto equal_range_impl(This&& self, Key const &key) {
     auto lower = self.lower_bound(key);
     using lower_t = decltype(lower);
-    if (lower == self.end())
-      return std::pair<lower_t, lower_t>{lower, lower};
-    else
+    if (lower != self.end() && !self.less_than_(key, *lower))
       return std::pair<lower_t, lower_t>{lower, lower + 1};
+    else
+      return std::pair<lower_t, lower_t>{lower, lower};
   }
 
   template <class This>
   static inline constexpr auto lower_bound_impl(This&& self, Key const &key) -> decltype(self.end()) {
-    auto where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
-    if ((where != self.end()) && !self.less_than_(key, *where))
-      return where;
-    else
-      return self.end();
+    return bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
   }
 
   template <class This>
-  static inline constexpr auto upper_bound_impl(This&& self, Key const &key) -> decltype(self.end()) {
-    auto where = bits::lower_bound<N>(self.items_.begin(), key, self.less_than_);
-    if ((where != self.end()) && !self.less_than_(key, *where))
-      return where + 1;
+  static inline constexpr auto upper_bound_impl(This&& self, Key const &key) {
+    auto lower = self.lower_bound(key);
+    if (lower != self.end() && !self.less_than_(key, *lower))
+      return lower + 1;
     else
-      return self.end();
+      return lower;
   }
 };
 

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -81,24 +81,29 @@ TEST_CASE("singleton frozen map", "[map]") {
   REQUIRE(find5 == ze_map.end());
 
   const auto range0 = ze_map.equal_range(0);
-  REQUIRE(std::get<0>(range0) == ze_map.end());
-  REQUIRE(std::get<1>(range0) == ze_map.end());
+  REQUIRE(std::get<0>(range0) == ze_map.begin());
+  REQUIRE(std::get<1>(range0) == ze_map.begin());
 
   const auto range1 = ze_map.equal_range(1);
   REQUIRE(std::get<0>(range1) == ze_map.begin());
   REQUIRE(std::get<1>(range1) == ze_map.end());
 
+  const auto range2 = ze_map.equal_range(2);
+  REQUIRE(std::get<0>(range2) == ze_map.end());
+  REQUIRE(std::get<1>(range2) == ze_map.end());
+
   const auto lower_bound0 = ze_map.lower_bound(0);
-  REQUIRE(lower_bound0 == ze_map.end());
+  REQUIRE(lower_bound0 == ze_map.begin());
 
   const auto lower_bound1 = ze_map.lower_bound(1);
+  REQUIRE(lower_bound0 == ze_map.begin());
   REQUIRE(lower_bound1 == ze_map.find(1));
 
   const auto lower_bound2 = ze_map.lower_bound(2);
   REQUIRE(lower_bound2 == ze_map.end());
 
   const auto upper_bound0 = ze_map.upper_bound(0);
-  REQUIRE(upper_bound0 == ze_map.end());
+  REQUIRE(upper_bound0 == ze_map.begin());
 
   const auto upper_bound1 = ze_map.upper_bound(1);
   REQUIRE(upper_bound1 == ze_map.end());
@@ -156,15 +161,15 @@ TEST_CASE("triple frozen map", "[map]") {
   REQUIRE(find15 == ze_map.end());
 
   const auto range0 = ze_map.equal_range(0);
-  REQUIRE(std::get<0>(range0) == ze_map.end());
-  REQUIRE(std::get<1>(range0) == ze_map.end());
+  REQUIRE(std::get<0>(range0) == ze_map.begin());
+  REQUIRE(std::get<1>(range0) == ze_map.begin());
 
   const auto range1 = ze_map.equal_range(10);
   REQUIRE(std::get<0>(range1) == ze_map.begin());
   REQUIRE(std::get<1>(range1) == ze_map.begin() + 1);
 
   const auto lower_bound0 = ze_map.lower_bound(0);
-  REQUIRE(lower_bound0 == ze_map.end());
+  REQUIRE(lower_bound0 == ze_map.begin());
 
   for (auto val : ze_map) {
     const auto lower_bound = ze_map.lower_bound(std::get<0>(val));
@@ -175,7 +180,7 @@ TEST_CASE("triple frozen map", "[map]") {
   REQUIRE(lower_bound2 == ze_map.end());
 
   const auto upper_bound0 = ze_map.upper_bound(0);
-  REQUIRE(upper_bound0 == ze_map.end());
+  REQUIRE(upper_bound0 == ze_map.begin());
 
   const auto upper_bound1 = ze_map.upper_bound(10);
   REQUIRE(upper_bound1 == (ze_map.begin() + 1));

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -171,13 +171,19 @@ TEST_CASE("triple frozen map", "[map]") {
   const auto lower_bound0 = ze_map.lower_bound(0);
   REQUIRE(lower_bound0 == ze_map.begin());
 
+  const auto lower_bound1 = ze_map.lower_bound(20);
+  REQUIRE(lower_bound1 == ze_map.begin() + 1);
+
+  const auto lower_bound2 = ze_map.lower_bound(25);
+  REQUIRE(lower_bound2 == ze_map.begin() + 2);
+
+  const auto lower_bound3 = ze_map.lower_bound(40);
+  REQUIRE(lower_bound3 == ze_map.end());
+
   for (auto val : ze_map) {
     const auto lower_bound = ze_map.lower_bound(std::get<0>(val));
     REQUIRE(lower_bound == ze_map.find(std::get<0>(val)));
   }
-
-  const auto lower_bound2 = ze_map.lower_bound(40);
-  REQUIRE(lower_bound2 == ze_map.end());
 
   const auto upper_bound0 = ze_map.upper_bound(0);
   REQUIRE(upper_bound0 == ze_map.begin());
@@ -185,8 +191,11 @@ TEST_CASE("triple frozen map", "[map]") {
   const auto upper_bound1 = ze_map.upper_bound(10);
   REQUIRE(upper_bound1 == (ze_map.begin() + 1));
 
-  const auto upper_bound2 = ze_map.upper_bound(40);
-  REQUIRE(upper_bound2 == ze_map.end());
+  const auto upper_bound2 = ze_map.upper_bound(15);
+  REQUIRE(upper_bound2 == ze_map.begin() + 1);
+
+  const auto upper_bound3 = ze_map.upper_bound(40);
+  REQUIRE(upper_bound3 == ze_map.end());
 
   auto const begin = ze_map.begin(), end = ze_map.end();
   REQUIRE((begin + ze_map.size()) == end);
@@ -321,6 +330,9 @@ TEST_CASE("Modifiable frozen::map", "[map]") {
   }
 
   SECTION("Lookup failure") {
+    REQUIRE(frozen_map.find(3) == frozen_map.end());
+    REQUIRE_THROWS_AS(frozen_map.at(3), std::out_of_range);
+
     REQUIRE(frozen_map.find(5) == frozen_map.end());
     REQUIRE_THROWS_AS(frozen_map.at(5), std::out_of_range);
   }


### PR DESCRIPTION
Namely (quoting cppreference.com):

- `lower_bound` "Returns an iterator pointing to the first element that is not less than (i.e. greater or equal to) key."
- `upper_bound` "Returns an iterator pointing to the first element that is greater than key."
- `equal_range` "Returns a range containing all elements with the given key in the container. The range is defined by two iterators, one pointing to the first element that is not less than key and another pointing to the first element greater than key."