### PR TITLE
feature: deduction guides for sets

### DIFF
--- a/.github/workflows/frozen.yml
+++ b/.github/workflows/frozen.yml
@@ -14,6 +14,9 @@ jobs:
           - macOS-latest
         cmake_args:
           - ""
+        cxxstandard:
+          - 14
+          - 17
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -25,7 +28,7 @@ jobs:
 
     - name: Configure
       working-directory: build
-      run: cmake -DCMAKE_BUILD_TYPE=DEBUG "-Dfrozen.coverage=ON" -DCMAKE_VERBOSE_MAKEFILE=ON ..
+      run: cmake -DCMAKE_BUILD_TYPE=DEBUG "-Dfrozen.coverage=ON" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_STANDARD=${{matrix.cxxstandard}} ..
 
     - name: Build
       working-directory: build

--- a/.github/workflows/frozen.yml
+++ b/.github/workflows/frozen.yml
@@ -14,9 +14,6 @@ jobs:
           - macOS-latest
         cmake_args:
           - ""
-        cxxstandard:
-          - 14
-          - 17
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -28,7 +25,7 @@ jobs:
 
     - name: Configure
       working-directory: build
-      run: cmake -DCMAKE_BUILD_TYPE=DEBUG "-Dfrozen.coverage=ON" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_STANDARD=${{matrix.cxxstandard}} ..
+      run: cmake -DCMAKE_BUILD_TYPE=DEBUG "-Dfrozen.coverage=ON" -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
     - name: Build
       working-directory: build

--- a/.github/workflows/frozen.yml
+++ b/.github/workflows/frozen.yml
@@ -14,6 +14,9 @@ jobs:
           - macOS-latest
         cmake_args:
           - ""
+        cxxstandard:
+          - 14
+          - 17
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -25,6 +28,8 @@ jobs:
 
     - name: Configure
       working-directory: build
+      env:
+          CXXFLAGS: ${{matrix.os == 'windows-latest' && '/std:' || '-std='}}c++${{matrix.cxxstandard}}
       run: cmake -DCMAKE_BUILD_TYPE=DEBUG "-Dfrozen.coverage=ON" -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
     - name: Build

--- a/include/frozen/bits/defines.h
+++ b/include/frozen/bits/defines.h
@@ -55,4 +55,8 @@
   #define FROZEN_LETITGO_HAS_CHAR8T
 #endif
 
+#if __cpp_deduction_guides >= 201703L
+  #define FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+#endif
+
 #endif // FROZEN_LETITGO_DEFINES_H

--- a/include/frozen/set.h
+++ b/include/frozen/set.h
@@ -27,6 +27,7 @@
 #include "frozen/bits/basic_types.h"
 #include "frozen/bits/constexpr_assert.h"
 #include "frozen/bits/version.h"
+#include "frozen/bits/defines.h"
 
 #include <utility>
 
@@ -73,6 +74,8 @@ public:
 
   constexpr set(std::initializer_list<Key> keys)
       : set{keys, Compare{}} {}
+
+  constexpr set& operator=(const set &other) = default;
 
   /* capacity */
   constexpr bool empty() const { return !N; }
@@ -171,6 +174,8 @@ public:
       : less_than_{comp} {}
   constexpr set(std::initializer_list<Key> keys) : set{keys, Compare{}} {}
 
+  constexpr set& operator=(const set &other) = default;
+
   /* capacity */
   constexpr bool empty() const { return true; }
   constexpr size_type size() const { return 0; }
@@ -219,6 +224,12 @@ constexpr auto make_set(std::array<T, N> const &args) {
   return set<T, N>(args);
 }
 
+#ifdef FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+
+template<class T, class... Args>
+set(T, Args...) -> set<T, sizeof...(Args) + 1>;
+
+#endif // FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
 
 } // namespace frozen
 

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -147,6 +147,13 @@ constexpr auto make_unordered_set(std::array<T, N> const &keys) {
   return unordered_set<T, N>{keys};
 }
 
+#ifdef FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+
+template <class T, class... Args>
+unordered_set(T, Args...) -> unordered_set<T, sizeof...(Args) + 1>;
+
+#endif
+
 } // namespace frozen
 
 #endif

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -2,6 +2,7 @@
 #include <frozen/set.h>
 #include <iostream>
 #include <set>
+#include <type_traits>
 
 #include "bench.hpp"
 #include "catch.hpp"
@@ -277,3 +278,14 @@ TEST_CASE("frozen::set of frozen::set", "[set]") {
   static_assert(!ce.count(s1({0})), "");
   static_assert(ce.find(s1({0})) == ce.end(), "");
 }
+
+#ifdef FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+
+TEST_CASE("frozen::set deduction guide", "[set]") {
+    constexpr frozen::set integersSet{1,2,3,4,5};
+    static_assert(std::is_same<
+            std::remove_cv_t<decltype(integersSet)>,
+            frozen::set<int, 5>>::value, "wrong type deduced");
+}
+
+#endif // FROZEN_LETITGO_HAS_DEDUCTION_GUIDES

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -156,3 +156,14 @@ TEST_CASE("frozen::unordered_set constexpr", "[unordered_set]") {
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
 }
+
+#ifdef FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+
+TEST_CASE("frozen::unordered_set deduction guide", "[unordered_set]") {
+    constexpr frozen::unordered_set integersSet{1,2,3,4,5};
+    static_assert(std::is_same<
+            std::remove_cv_t<decltype(integersSet)>,
+            frozen::unordered_set<int, 5>>::value, "wrong type deduced");
+}
+
+#endif // FROZEN_LETITGO_HAS_DEDUCTION_GUIDES


### PR DESCRIPTION
The guides will allow to create variables like this:
```cpp
constexpr frozen::set integersSet{1,2,3,4,5};
```