### PR TITLE
feature: elsa for std string types

### DIFF
--- a/include/frozen/bits/defines.h
+++ b/include/frozen/bits/defines.h
@@ -59,4 +59,8 @@
   #define FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
 #endif
 
+#if __cpp_lib_constexpr_string >= 201907L
+  #define FROZEN_LETITGO_HAS_CONSTEXPR_STRING
+#endif
+
 #endif // FROZEN_LETITGO_DEFINES_H

--- a/include/frozen/bits/elsa_std.h
+++ b/include/frozen/bits/elsa_std.h
@@ -1,0 +1,40 @@
+#ifndef FROZEN_LETITGO_BITS_ELSA_STD_H
+#define FROZEN_LETITGO_BITS_ELSA_STD_H
+
+#include "elsa.h"
+#include "hash_string.h"
+
+#ifdef FROZEN_LETITGO_HAS_STRING_VIEW
+#include <string_view>
+#endif
+#include <string>
+
+namespace frozen {
+
+#ifdef FROZEN_LETITGO_HAS_STRING_VIEW
+
+template <typename CharT> struct elsa<std::basic_string_view<CharT>>
+{
+    constexpr std::size_t operator()(const std::basic_string_view<CharT>& value) const {
+        return hash_string(value);
+    }
+    constexpr std::size_t operator()(const std::basic_string_view<CharT>& value, std::size_t seed) const {
+        return hash_string(value, seed);
+    }
+};
+
+#endif
+
+template <typename CharT> struct elsa<std::basic_string<CharT>>
+{
+    constexpr std::size_t operator()(const std::basic_string<CharT>& value) const {
+        return hash_string(value);
+    }
+    constexpr std::size_t operator()(const std::basic_string<CharT>& value, std::size_t seed) const {
+        return hash_string(value, seed);
+    }
+};
+
+} // namespace frozen
+
+#endif // FROZEN_LETITGO_BITS_ELSA_STD_H

--- a/include/frozen/bits/hash_string.h
+++ b/include/frozen/bits/hash_string.h
@@ -1,0 +1,28 @@
+#ifndef FROZEN_LETITGO_BITS_HASH_STRING_H
+#define FROZEN_LETITGO_BITS_HASH_STRING_H
+
+#include <cstddef>
+
+namespace frozen {
+
+template <typename String>
+constexpr std::size_t hash_string(const String& value) {
+  std::size_t d = 5381;
+  for (const auto& c : value)
+    d = d * 33 + static_cast<size_t>(c);
+  return d;
+}
+
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+// With the lowest bits removed, based on experimental setup.
+template <typename String>
+constexpr std::size_t hash_string(const String& value, std::size_t seed) {
+  std::size_t d =  (0x811c9dc5 ^ seed) * static_cast<size_t>(0x01000193);
+  for (const auto& c : value)
+    d = (d ^ static_cast<size_t>(c)) * static_cast<size_t>(0x01000193);
+  return d >> 8 ;
+}
+
+} // namespace frozen
+
+#endif // FROZEN_LETITGO_BITS_HASH_STRING_H

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -24,6 +24,7 @@
 #define FROZEN_LETITGO_STRING_H
 
 #include "frozen/bits/elsa.h"
+#include "frozen/bits/hash_string.h"
 #include "frozen/bits/version.h"
 #include "frozen/bits/defines.h"
 
@@ -85,22 +86,16 @@ public:
   }
 
   constexpr const chr_t *data() const { return data_; }
+  constexpr const chr_t *begin() const { return data(); }
+  constexpr const chr_t *end() const { return data() + size(); }
 };
 
 template <typename _CharT> struct elsa<basic_string<_CharT>> {
   constexpr std::size_t operator()(basic_string<_CharT> value) const {
-    std::size_t d = 5381;
-    for (std::size_t i = 0; i < value.size(); ++i)
-      d = d * 33 + static_cast<size_t>(value[i]);
-    return d;
+    return hash_string(value);
   }
-  // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-  // With the lowest bits removed, based on experimental setup.
   constexpr std::size_t operator()(basic_string<_CharT> value, std::size_t seed) const {
-    std::size_t d =  (0x811c9dc5 ^ seed) * static_cast<size_t>(0x01000193);
-    for (std::size_t i = 0; i < value.size(); ++i)
-      d = (d ^ static_cast<size_t>(value[i])) * static_cast<size_t>(0x01000193);
-    return d >> 8 ;
+    return hash_string(value, seed);
   }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(frozen.tests PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/bench.hpp
   ${CMAKE_CURRENT_LIST_DIR}/catch.hpp
   ${CMAKE_CURRENT_LIST_DIR}/test_algorithms.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/test_elsa_std.cpp
   ${CMAKE_CURRENT_LIST_DIR}/test_main.cpp
   ${CMAKE_CURRENT_LIST_DIR}/test_map.cpp
   ${CMAKE_CURRENT_LIST_DIR}/test_rand.cpp

--- a/tests/test_elsa_std.cpp
+++ b/tests/test_elsa_std.cpp
@@ -1,0 +1,44 @@
+#include <frozen/bits/defines.h>
+
+#ifdef FROZEN_LETITGO_HAS_STRING_VIEW
+
+#include <frozen/bits/elsa_std.h>
+#include <frozen/map.h>
+#include <frozen/set.h>
+#include <frozen/unordered_map.h>
+#include <frozen/unordered_set.h>
+
+#include "catch.hpp"
+
+#include <string_view>
+
+#ifdef FROZEN_LETITGO_HAS_CONSTEXPR_STRING
+
+#include <string>
+
+using StringTypes = std::tuple<std::string_view, std::string>;
+
+#else
+
+using StringTypes = std::tuple<std::string_view>;
+
+#endif
+
+TEMPLATE_LIST_TEST_CASE("frozen containers work with standard string types", "[elsa_std]", StringTypes)
+{
+    constexpr TestType str = "string";
+
+    const auto is_found_in = [&str](const auto& container){ return container.count(str) == 1; };
+
+    constexpr frozen::set set{str};
+    constexpr frozen::unordered_set unordered_set{str};
+    constexpr auto map = frozen::make_map<TestType, int>({{str, 0}});
+    constexpr auto unordered_map = frozen::make_unordered_map<TestType, int>({{str, 0}});
+
+    REQUIRE(is_found_in(set));
+    REQUIRE(is_found_in(unordered_set));
+    REQUIRE(is_found_in(map));
+    REQUIRE(is_found_in(unordered_map));
+}
+
+#endif // FROZEN_LETITGO_HAS_STRING_VIEW


### PR DESCRIPTION
This will allow using frozen containers with `std::string_view`(C++17) and `std::string`(C++20). I'm not sure if tests are needed for this ... I plan to add a heterogeneous search in the next PR, there it will already be possible to write tests that will use the hash for `std::string_view`.