### PR TITLE
feature: heterogeneous lookup

### DIFF
--- a/include/frozen/bits/elsa.h
+++ b/include/frozen/bits/elsa.h
@@ -27,7 +27,7 @@
 
 namespace frozen {
 
-template <class T> struct elsa {
+template <class T = void> struct elsa {
   static_assert(std::is_integral<T>::value || std::is_enum<T>::value,
                 "only supports integral types, specialize for other types");
 
@@ -41,6 +41,13 @@ template <class T> struct elsa {
     key = key ^ (key >> 28);
     key = key + (key << 31);
     return key;
+  }
+};
+
+template <> struct elsa<void> {
+  template<class T>
+  constexpr std::size_t operator()(T const &value, std::size_t seed) const {
+    return elsa<T>{}(value, seed);
   }
 };
 

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -156,13 +156,18 @@ struct pmh_tables {
   carray<std::size_t, M> second_table_;
   Hasher hash_;
 
-  // Looks up a given key, to find its expected index in carray<Item, N>
-  // Always returns a valid index, must use KeyEqual test after to confirm.
   template <typename KeyType>
   constexpr std::size_t lookup(const KeyType & key) const {
-    auto const d = first_table_[hash_(key, static_cast<size_t>(first_seed_)) % M];
+    return lookup(key, hash_);
+  }
+
+  // Looks up a given key, to find its expected index in carray<Item, N>
+  // Always returns a valid index, must use KeyEqual test after to confirm.
+  template <typename KeyType, typename HasherType>
+  constexpr std::size_t lookup(const KeyType & key, const HasherType& hasher) const {
+    auto const d = first_table_[hasher(key, static_cast<size_t>(first_seed_)) % M];
     if (!d.is_seed()) { return static_cast<std::size_t>(d.value()); } // this is narrowing uint64 -> size_t but should be fine
-    else { return second_table_[hash_(key, static_cast<std::size_t>(d.value())) % M]; }
+    else { return second_table_[hasher(key, static_cast<std::size_t>(d.value())) % M]; }
   }
 };
 

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -1,7 +1,9 @@
 #include <frozen/unordered_map.h>
 #include <frozen/string.h>
+#include <frozen/bits/elsa_std.h>
 #include <iostream>
 #include <unordered_map>
+#include <string>
 
 #include "bench.hpp"
 #include "catch.hpp"
@@ -220,4 +222,27 @@ TEST_CASE("Modifiable frozen::unordered_map", "[unordered_map]") {
     frozen_map.equal_range(4).first->second = -5;
     REQUIRE(frozen_map.at(4) == -5);
   }
+}
+
+TEST_CASE("frozen::unordered_map heterogeneous lookup", "[unordered_map]") {
+  constexpr auto map = frozen::make_unordered_map<frozen::string, int>({{"one", 1}, {"two", 2}, {"three", 3}});
+
+  const auto eq = [](const frozen::string& frozen, const std::string& std) {
+      return frozen == frozen::string{std.data(), std.size()};
+  };
+
+  REQUIRE(map.find(std::string{"two"}, frozen::elsa<std::string>{}, eq)->second == 2);
+}
+
+TEST_CASE("frozen::unordered_map heterogeneous container", "[unordered_map]") {
+  const auto eq = [](const frozen::string& frozen, const auto& str) {
+    return frozen == frozen::string{str.data(), str.size()};
+  };
+
+  constexpr auto map = frozen::make_unordered_map<frozen::string, int>(
+          {{"one", 1}, {"two", 2}, {"three", 3}},
+          frozen::elsa<>{}, eq);
+
+  REQUIRE(map.find(std::string{"two"})->second == 2);
+  REQUIRE(map.find(frozen::string{"two"})->second == 2);
 }

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -1,7 +1,9 @@
 #include <frozen/string.h>
 #include <frozen/unordered_set.h>
+#include <frozen/bits/elsa_std.h>
 #include <iostream>
 #include <unordered_set>
+#include <string>
 
 #include "bench.hpp"
 #include "catch.hpp"
@@ -167,3 +169,28 @@ TEST_CASE("frozen::unordered_set deduction guide", "[unordered_set]") {
 }
 
 #endif // FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
+
+TEST_CASE("frozen::unordered_set heterogeneous lookup", "[unordered_map]") {
+  using namespace frozen::string_literals;
+
+  constexpr frozen::unordered_set set{"one"_s, "two"_s, "three"_s};
+
+  const auto eq = [](const frozen::string& frozen, const std::string& std) {
+    return frozen == frozen::string{std.data(), std.size()};
+  };
+
+  REQUIRE(set.find(std::string{"two"}, frozen::elsa<std::string>{}, eq) != set.end());
+}
+
+TEST_CASE("frozen::unordered_set heterogeneous container", "[unordered_map]") {
+  const auto eq = [](const frozen::string& frozen, const auto& str) {
+    return frozen == frozen::string{str.data(), str.size()};
+  };
+
+  constexpr auto set = frozen::make_unordered_set<frozen::string>(
+          {"one", "two", "three"},
+          frozen::elsa<>{}, eq);
+
+  REQUIRE(set.find(std::string{"two"}) != set.end());
+  REQUIRE(set.find(frozen::string{"two"}) != set.end());
+}


### PR DESCRIPTION
This PR adds heterogeneous lookup for unordered containers(set,map). Now you can search for another type in 2 ways: 
1. Use special `find` (and other functions) signature and pass hash and equal functions.
2. Create a container with heterogenous `frozen::elsa<>` and `std::equal_to<>`.   

To my surprise, ordered map already have heterogeneous lookup, but I don’t understand why there are such overcomplications from my point of view as `CompareKey`. I think we need to refactor this and add a lookup for `set` separately.