### PR TITLE
Boyer-Moore checks

### DIFF
--- a/include/frozen/algorithm.h
+++ b/include/frozen/algorithm.h
@@ -171,6 +171,9 @@ public:
     if (size == 0)
       return { first, first + size };
 
+    if (size > last - first)
+      return { last, last};  
+
     ForwardIterator iter = first + size - 1;
     while (iter < last) {
       std::ptrdiff_t j = size - 1;
@@ -178,12 +181,12 @@ public:
         --iter;
         --j;
       }
-      if (*iter == needle_[0])
+      if (*iter == needle_[0] && (iter <= last - size))
         return { iter, iter + size};
 
-      iter += std::max(skip_table_[*iter], suffix_table_[j]);
+      iter += std::min(last - iter, std::max(skip_table_[*iter], suffix_table_[j]));
     }
-    return { last, last + size};
+    return { last, last};
   }
 };
 

--- a/include/frozen/algorithm.h
+++ b/include/frozen/algorithm.h
@@ -166,27 +166,29 @@ public:
       suffix_table_{build_suffix_table(needle)},
       needle_(needle) {}
 
-  template <class ForwardIterator>
-  constexpr std::pair<ForwardIterator, ForwardIterator> operator()(ForwardIterator first, ForwardIterator last) const {
+  template <class RandomAccessIterator>
+  constexpr std::pair<RandomAccessIterator, RandomAccessIterator> operator()(RandomAccessIterator first, RandomAccessIterator last) const {
     if (size == 0)
-      return { first, first + size };
+      return { first, first };
 
-    if (size > last - first)
-      return { last, last};  
+    if (size > size_t(last - first))
+      return { last, last };
 
-    ForwardIterator iter = first + size - 1;
-    while (iter < last) {
+    RandomAccessIterator iter = first + size - 1;
+    while (true) {
       std::ptrdiff_t j = size - 1;
       while (j > 0 && (*iter == needle_[j])) {
         --iter;
         --j;
       }
-      if (*iter == needle_[0] && (iter <= last - size))
+      if (j == 0 && *iter == needle_[0])
         return { iter, iter + size};
 
-      iter += std::min(last - iter, std::max(skip_table_[*iter], suffix_table_[j]));
+      std::ptrdiff_t jump = std::max(skip_table_[*iter], suffix_table_[j]);
+      if (jump >= last - iter)
+        return { last, last };
+      iter += jump;
     }
-    return { last, last};
   }
 };
 

--- a/tests/test_str.cpp
+++ b/tests/test_str.cpp
@@ -205,6 +205,23 @@ TEST_CASE("Knuth-Morris-Pratt str search", "[str-search]") {
     REQUIRE(index == haystack.end());
   }
 
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_knuth_morris_pratt_searcher("n*"));
+    REQUIRE(index == haystack.end());
+  }
+
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_knuth_morris_pratt_searcher("nnnn"));
+    REQUIRE(index == haystack.end());
+  }
+
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_knuth_morris_pratt_searcher("nmnn*"));
+    REQUIRE(index == haystack.end());
+  }
 
   {
     std::string haystack = "ABC ABCDAB ABCDABCDABDE";
@@ -234,6 +251,23 @@ TEST_CASE("Boyer-Moore str search", "[str-search]") {
     REQUIRE(index == haystack.end());
   }
 
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_boyer_moore_searcher("n*"));
+    REQUIRE(index == haystack.end());
+  }
+
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_boyer_moore_searcher("nnnn"));
+    REQUIRE(index == haystack.end());
+  }
+
+  {
+    std::string haystack = "nmnn";
+    auto index = frozen::search(haystack.begin(), haystack.end(), frozen::make_boyer_moore_searcher("nmnn*"));
+    REQUIRE(index == haystack.end());
+  }
 
   {
     std::string haystack = "ABC ABCDAB ABCDABCDABDE";


### PR DESCRIPTION
It seems that at some point in time, assigning a string iterator a value past-the-end of the string became quite illegal, at least in MSVC's STL. As such, the Boyer-Moore search would throw, including in one of the existing tests (the one expecting the needle to not be found).
As such, I've added extra checks to ensure no iterator is ever set past last in there.
I've also added a few extra tests to check for such edge cases that would set any iterator past-the-end as well.