### PR TITLE
Add c++20 'contains' member functions to the associative containers

### DIFF
--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -154,6 +154,11 @@ public:
   }
   
   template <class KeyType>
+  constexpr bool contains(KeyType const &key) const {
+    return this->find(key) != this->end();
+  }
+  
+  template <class KeyType>
   constexpr std::pair<const_iterator, const_iterator>
   equal_range(KeyType const &key) const {
     return equal_range_impl(*this, key);

--- a/include/frozen/set.h
+++ b/include/frozen/set.h
@@ -96,6 +96,11 @@ public:
     else
       return end();
   }
+  
+  template <class KeyType>
+  constexpr bool contains(KeyType const &key) const {
+    return this->find(key) != keys_.end();
+  }
 
   template <class KeyType>
   constexpr std::pair<const_iterator, const_iterator> equal_range(KeyType const &key) const {

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -154,6 +154,11 @@ public:
   constexpr iterator find(KeyType const &key) {
     return find(key, hash_function(), key_eq());
   }
+  
+  template <class KeyType>
+  constexpr bool contains(KeyType const &key) const {
+    return this->find(key) != this->end();
+  }
 
   template <class KeyType, class Hasher, class Equal>
   constexpr std::pair<const_iterator, const_iterator> equal_range(KeyType const &key, Hasher const &hash, Equal const &equal) const {

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -125,6 +125,11 @@ public:
   constexpr const_iterator find(KeyType const &key) const {
     return find(key, hash_function(), key_eq());
   }
+  
+  template <class KeyType>
+  constexpr bool contains(KeyType const &key) const {
+    return this->find(key) != keys_.end();
+  }
 
   template <class KeyType, class Hasher, class Equal>
   constexpr std::pair<const_iterator, const_iterator> equal_range(

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -311,6 +311,8 @@ TEST_CASE("frozen::map constexpr", "[map]") {
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
   static_assert(ce.at(3) == 4, "");
+  static_assert(ce.contains(3), "");
+  static_assert(!ce.contains(0), "");
 }
 
 TEST_CASE("Modifiable frozen::map", "[map]") {

--- a/tests/test_set.cpp
+++ b/tests/test_set.cpp
@@ -267,6 +267,8 @@ TEST_CASE("frozen::set constexpr", "[set]") {
   static_assert(ce.count(3), "");
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
+  static_assert(ce.contains(3), "");
+  static_assert(!ce.contains(0), "");
 }
 
 TEST_CASE("frozen::set of frozen::set", "[set]") {
@@ -278,6 +280,8 @@ TEST_CASE("frozen::set of frozen::set", "[set]") {
   static_assert(ce.count(s1({3})), "");
   static_assert(!ce.count(s1({0})), "");
   static_assert(ce.find(s1({0})) == ce.end(), "");
+  static_assert(ce.contains(s1({3})), "");
+  static_assert(!ce.contains(s1({0})), "");
 }
 
 struct Foo {

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -179,6 +179,8 @@ TEST_CASE("frozen::unordered_map constexpr", "[unordered_map]") {
   static_assert(ce.count(3), "");
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
+  static_assert(ce.contains(3), "");
+  static_assert(!ce.contains(0), "");
 }
 
 TEST_CASE("access", "[unordered_map]") {

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -158,6 +158,8 @@ TEST_CASE("frozen::unordered_set constexpr", "[unordered_set]") {
   static_assert(ce.count(3), "");
   static_assert(!ce.count(0), "");
   static_assert(ce.find(0) == ce.end(), "");
+  static_assert(ce.contains(3), "");
+  static_assert(!ce.contains(0), "");
 }
 
 #ifdef FROZEN_LETITGO_HAS_DEDUCTION_GUIDES


### PR DESCRIPTION
C++20 added `contains` to its (unordered) set and map types. To achieve feature parity with those I have added such member functions.