### PR TITLE
Fix closure types not being literal types and thus not constexpr-comp…

### DIFF
--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -185,16 +185,19 @@ TEST_CASE("frozen::unordered_set heterogeneous lookup", "[unordered_set]") {
   REQUIRE(set.find(std::string{"two"}, frozen::elsa<std::string>{}, eq) != set.end());
 }
 
+struct eq {
+  template<class StrTy>
+  auto operator()(const frozen::string &frozen, const StrTy &str) const {
+    return frozen == frozen::string{str.data(), str.size()};
+  }
+};
+
 TEST_CASE("frozen::unordered_set heterogeneous container", "[unordered_set]") {
   using namespace frozen::string_literals;
 
-  const auto eq = [](const frozen::string& frozen, const auto& str) {
-    return frozen == frozen::string{str.data(), str.size()};
-  };
-
   constexpr auto set = frozen::make_unordered_set<frozen::string>(
           {"one"_s, "two"_s, "three"_s},
-          frozen::elsa<>{}, eq);
+          frozen::elsa<>{}, eq{});
 
   REQUIRE(set.find(std::string{"two"}) != set.end());
   REQUIRE(set.find(frozen::string{"two"}) != set.end());


### PR DESCRIPTION
…atible

Closure types are literal types only starting with C++17, don't use them in our C++14 compatible code base.

Fix #150