### PR TITLE
minor fixes and improvements

### DIFF
--- a/include/frozen/algorithm.h
+++ b/include/frozen/algorithm.h
@@ -47,9 +47,7 @@ template <std::size_t size> class knuth_morris_pratt_searcher {
   static constexpr bits::carray<std::ptrdiff_t, size>
   build_kmp_cache(char const (&needle)[size + 1]) {
     std::ptrdiff_t cnd = 0;
-    bits::carray<std::ptrdiff_t, size> cache;
-
-    cache.fill(-1);
+    bits::carray<std::ptrdiff_t, size> cache(-1);
     for (std::size_t pos = 1; pos < size; ++pos) {
       if (needle[pos] == needle[cnd]) {
         cache[pos] = cache[cnd];
@@ -109,9 +107,7 @@ template <std::size_t size> class boyer_moore_searcher {
   bits::carray<char, size> needle_;
 
   constexpr auto build_skip_table(char const (&needle)[size + 1]) {
-    skip_table_type skip_table;
-
-    skip_table.fill(size);
+    skip_table_type skip_table(size);
     for (std::size_t i = 0; i < size - 1; ++i)
       skip_table[needle[i]] -= i + 1;
     return skip_table;

--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -109,19 +109,25 @@ constexpr void cswap(std::tuple<Tys...> &a, std::tuple<Tys...> &b) {
   cswap(a, b, std::make_index_sequence<sizeof...(Tys)>());
 }
 
+template <typename Iter>
+constexpr void iter_swap(Iter a, Iter b) {
+  cswap(*a, *b);
+}
+
 template <typename Iterator, class Compare>
 constexpr Iterator partition(Iterator left, Iterator right, Compare const &compare) {
   auto pivot = left + (right - left) / 2;
-  auto value = *pivot;
-  cswap(*right, *pivot);
+  iter_swap(right, pivot);
+  pivot = right;
   for (auto it = left; 0 < right - it; ++it) {
-    if (compare(*it, value)) {
-      cswap(*it, *left);
+    if (compare(*it, *pivot)) {
+      iter_swap(it, left);
       left++;
     }
   }
-  cswap(*right, *left);
-  return left;
+  iter_swap(pivot, left);
+  pivot = left;
+  return pivot;
 }
 
 template <typename Iterator, class Compare>

--- a/include/frozen/bits/algorithms.h
+++ b/include/frozen/bits/algorithms.h
@@ -139,10 +139,10 @@ constexpr void quicksort(Iterator left, Iterator right, Compare const &compare) 
   }
 }
 
-template <typename T, std::size_t N, class Compare>
-constexpr bits::carray<T, N> quicksort(bits::carray<T, N> const &array,
+template <typename Container, class Compare>
+constexpr Container quicksort(Container const &array,
                                      Compare const &compare) {
-  bits::carray<T, N> res = array;
+  Container res = array;
   quicksort(res.begin(), res.end() - 1, compare);
   return res;
 }

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -27,7 +27,6 @@
 
 #include <array>
 #include <utility>
-#include <iterator>
 #include <string>
 
 namespace frozen {
@@ -106,8 +105,6 @@ public:
   using const_pointer = const value_type *;
   using iterator = pointer;
   using const_iterator = const_pointer;
-  using reverse_iterator = std::reverse_iterator<iterator>;
-  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
 
@@ -137,17 +134,8 @@ public:
   // Iterators
   constexpr iterator begin() noexcept { return data_; }
   constexpr const_iterator begin() const noexcept { return data_; }
-  constexpr const_iterator cbegin() const noexcept { return data_; }
   constexpr iterator end() noexcept { return data_ + N; }
   constexpr const_iterator end() const noexcept { return data_ + N; }
-  constexpr const_iterator cend() const noexcept { return data_ + N; }
-
-  constexpr reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-  constexpr const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-  constexpr const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
-  constexpr reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
-  constexpr const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
-  constexpr const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
 
   // Capacity
   constexpr size_type size() const { return N; }
@@ -189,8 +177,6 @@ public:
   using const_pointer = const value_type *;
   using iterator = pointer;
   using const_iterator = const_pointer;
-  using reverse_iterator = std::reverse_iterator<iterator>;
-  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
 

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -61,8 +61,10 @@ public:
   }
 
   // Iterators
-  constexpr iterator begin() noexcept { return data; }
-  constexpr iterator end() noexcept { return data + dsize; }
+  constexpr       iterator begin() noexcept { return data; }
+  constexpr       iterator end() noexcept { return data + dsize; }
+  constexpr const_iterator begin() const noexcept { return data; }
+  constexpr const_iterator end() const noexcept { return data + dsize; }
 
   // Capacity
   constexpr size_type size() const { return dsize; }

--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -93,6 +93,9 @@ class carray {
   template <class Iter, std::size_t... I>
   constexpr carray(Iter iter, std::index_sequence<I...>)
       : data_{((void)I, *iter++)...} {}
+  template <std::size_t... I>
+  constexpr carray(const T& value, std::index_sequence<I...>)
+      : data_{((void)I, value)...} {}
 
 public:
   // Container typdefs
@@ -109,7 +112,9 @@ public:
   using difference_type = std::ptrdiff_t;
 
   // Constructors
-  constexpr carray(void) = default;
+  constexpr carray() = default;
+  constexpr carray(const value_type& val)
+    : carray(val, std::make_index_sequence<N>()) {}
   template <std::size_t M>
   constexpr carray(T const (&init)[M])
     : carray(init, std::make_index_sequence<N>())
@@ -171,12 +176,6 @@ public:
 
   constexpr       value_type* data() noexcept { return data_; }
   constexpr const value_type* data() const noexcept { return data_; }
-
-  // Modifiers
-  constexpr void fill(const value_type& val) {
-    for (std::size_t i = 0; i < N; ++i)
-      data_[i] = val;
-  }
 };
 template <class T>
 class carray<T, 0> {

--- a/include/frozen/bits/elsa_std.h
+++ b/include/frozen/bits/elsa_std.h
@@ -1,6 +1,7 @@
 #ifndef FROZEN_LETITGO_BITS_ELSA_STD_H
 #define FROZEN_LETITGO_BITS_ELSA_STD_H
 
+#include "defines.h"
 #include "elsa.h"
 #include "hash_string.h"
 

--- a/include/frozen/bits/mpl.h
+++ b/include/frozen/bits/mpl.h
@@ -1,0 +1,56 @@
+/*
+ * Frozen
+ * Copyright 2022 Giel van Schijndel
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef FROZEN_LETITGO_BITS_MPL_H
+#define FROZEN_LETITGO_BITS_MPL_H
+
+#include <utility>
+
+namespace frozen {
+
+namespace bits {
+
+// Forward declarations
+template <class, std::size_t>
+class carray;
+
+template <typename T>
+struct remove_cv : std::remove_cv<T> {};
+
+template <typename... T>
+struct remove_cv<std::pair<T...>> {
+  using type = std::pair<typename remove_cv<T>::type...>;
+};
+
+template <typename T, std::size_t N>
+struct remove_cv<carray<T, N>> {
+  using type = carray<typename remove_cv<T>::type, N>;
+};
+
+template <typename T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+} // namespace bits
+
+} // namespace frozen
+
+#endif

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -96,16 +96,12 @@ pmh_buckets<M> constexpr make_pmh_buckets(const carray<Item, N> & items,
                                 Key const & key,
                                 PRG & prg) {
   using result_t = pmh_buckets<M>;
-  result_t result{};
-  bool rejected = false;
   // Continue until all items are placed without exceeding bucket_max
   while (1) {
-    for (auto & b : result.buckets) {
-      b.clear();
-    }
+    result_t result{};
     result.seed = prg();
-    rejected = false;
-    for (std::size_t i = 0; i < N; ++i) {
+    bool rejected = false;
+    for (std::size_t i = 0; i < items.size(); ++i) {
       auto & bucket = result.buckets[hash(key(items[i]), static_cast<std::size_t>(result.seed)) % M];
       if (bucket.size() >= result_t::bucket_max) {
         rejected = true;

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -204,12 +204,10 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const carray<Item, N> &
   const auto UNUSED = items.size();
 
   // G becomes the first hash table in the resulting pmh function
-  carray<seed_or_index, M> G; // Default constructed to "index 0"
-  G.fill({false, UNUSED});
+  carray<seed_or_index, M> G({false, UNUSED});
 
   // H becomes the second hash table in the resulting pmh function
-  carray<std::size_t, M> H;
-  H.fill(UNUSED);
+  carray<std::size_t, M> H(UNUSED);
 
   // Step 3: Map the items in buckets into hash tables.
   for (const auto & bucket : buckets) {

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -148,15 +148,29 @@ public:
 
 // Represents the perfect hash function created by pmh algorithm
 template <std::size_t M, class Hasher>
-struct pmh_tables {
+struct pmh_tables : private Hasher {
   std::uint64_t first_seed_;
   carray<seed_or_index, M> first_table_;
   carray<std::size_t, M> second_table_;
-  Hasher hash_;
+
+  constexpr pmh_tables(
+      std::uint64_t first_seed,
+      carray<seed_or_index, M> first_table,
+      carray<std::size_t, M> second_table,
+      Hasher hash) noexcept
+    : Hasher(hash)
+    , first_seed_(first_seed)
+    , first_table_(first_table)
+    , second_table_(second_table)
+  {}
+
+  constexpr Hasher const& hash_function() const noexcept {
+    return static_cast<Hasher const&>(*this);
+  }
 
   template <typename KeyType>
   constexpr std::size_t lookup(const KeyType & key) const {
-    return lookup(key, hash_);
+    return lookup(key, hash_function());
   }
 
   // Looks up a given key, to find its expected index in carray<Item, N>

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -27,6 +27,7 @@
 #include "frozen/bits/basic_types.h"
 #include "frozen/bits/constexpr_assert.h"
 #include "frozen/bits/exceptions.h"
+#include "frozen/bits/mpl.h"
 #include "frozen/bits/version.h"
 
 #include <iterator>
@@ -73,7 +74,7 @@ public:
 
 template <class Key, class Value, std::size_t N, class Compare = std::less<Key>>
 class map : private impl::CompareKey<Compare> {
-  using container_type = bits::carray<std::pair<Key, Value>, N>;
+  using container_type = bits::carray<std::pair<const Key, Value>, N>;
   container_type items_;
 
 public:
@@ -97,7 +98,7 @@ public:
   /* constructors */
   constexpr map(container_type items, Compare const &compare)
       : impl::CompareKey<Compare>{compare}
-      , items_{bits::quicksort(items, value_comp())} {}
+      , items_{bits::quicksort(bits::remove_cv_t<container_type>(items), value_comp())} {}
 
   explicit constexpr map(container_type items)
       : map{items, Compare{}} {}

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -81,7 +81,8 @@ public:
   using value_type = typename container_type::value_type;
   using size_type = typename container_type::size_type;
   using difference_type = typename container_type::difference_type;
-  using key_compare = impl::CompareKey<Compare>;
+  using key_compare = Compare;
+  using value_compare = impl::CompareKey<Compare>;
   using reference = typename container_type::reference;
   using const_reference = typename container_type::const_reference;
   using pointer = typename container_type::pointer;
@@ -187,8 +188,8 @@ public:
   }
 
   /* observers */
-  constexpr const key_compare& key_comp() const { return value_comp(); }
-  constexpr const key_compare& value_comp() const { return static_cast<impl::CompareKey<Compare> const&>(*this); }
+  constexpr const key_compare& key_comp() const { return value_comp().key_comp(); }
+  constexpr const value_compare& value_comp() const { return static_cast<impl::CompareKey<Compare> const&>(*this); }
 
  private:
   template <class This, class KeyType>
@@ -244,7 +245,8 @@ public:
   using value_type = typename container_type::value_type;
   using size_type = typename container_type::size_type;
   using difference_type = typename container_type::difference_type;
-  using key_compare = impl::CompareKey<Compare>;
+  using key_compare = Compare;
+  using value_compare = impl::CompareKey<Compare>;
   using reference = typename container_type::reference;
   using const_reference = typename container_type::const_reference;
   using pointer = typename container_type::pointer;
@@ -320,8 +322,8 @@ public:
   constexpr iterator upper_bound(KeyType const &) { return end(); }
 
 /* observers */
-  constexpr key_compare const& key_comp() const { return value_comp(); }
-  constexpr key_compare const& value_comp() const { return static_cast<impl::CompareKey<Compare> const&>(*this); }
+  constexpr key_compare const& key_comp() const { return value_comp().key_comp(); }
+  constexpr value_compare const& value_comp() const { return static_cast<impl::CompareKey<Compare> const&>(*this); }
 };
 
 template <typename T, typename U, typename Compare = std::less<T>>

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -29,6 +29,7 @@
 #include "frozen/bits/exceptions.h"
 #include "frozen/bits/version.h"
 
+#include <iterator>
 #include <utility>
 
 namespace frozen {
@@ -89,9 +90,8 @@ public:
   using const_pointer = typename container_type::const_pointer;
   using iterator = typename container_type::iterator;
   using const_iterator = typename container_type::const_iterator;
-  using reverse_iterator = typename container_type::reverse_iterator;
-  using const_reverse_iterator =
-      typename container_type::const_reverse_iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 public:
   /* constructors */
@@ -121,17 +121,17 @@ public:
   /* iterators */
   constexpr iterator begin() { return items_.begin(); }
   constexpr const_iterator begin() const { return items_.begin(); }
-  constexpr const_iterator cbegin() const { return items_.cbegin(); }
+  constexpr const_iterator cbegin() const { return items_.begin(); }
   constexpr iterator end() { return items_.end(); }
   constexpr const_iterator end() const { return items_.end(); }
-  constexpr const_iterator cend() const { return items_.cend(); }
+  constexpr const_iterator cend() const { return items_.end(); }
 
-  constexpr reverse_iterator rbegin() { return items_.rbegin(); }
-  constexpr const_reverse_iterator rbegin() const { return items_.rbegin(); }
-  constexpr const_reverse_iterator crbegin() const { return items_.crbegin(); }
-  constexpr reverse_iterator rend() { return items_.rend(); }
-  constexpr const_reverse_iterator rend() const { return items_.rend(); }
-  constexpr const_reverse_iterator crend() const { return items_.crend(); }
+  constexpr reverse_iterator rbegin() { return reverse_iterator{items_.end()}; }
+  constexpr const_reverse_iterator rbegin() const { return const_reverse_iterator{items_.end()}; }
+  constexpr const_reverse_iterator crbegin() const { return const_reverse_iterator{items_.end()}; }
+  constexpr reverse_iterator rend() { return reverse_iterator{items_.begin()}; }
+  constexpr const_reverse_iterator rend() const { return const_reverse_iterator{items_.begin()}; }
+  constexpr const_reverse_iterator crend() const { return const_reverse_iterator{items_.begin()}; }
 
   /* capacity */
   constexpr bool empty() const { return !N; }

--- a/include/frozen/set.h
+++ b/include/frozen/set.h
@@ -29,6 +29,7 @@
 #include "frozen/bits/version.h"
 #include "frozen/bits/defines.h"
 
+#include <iterator>
 #include <utility>
 
 namespace frozen {
@@ -50,9 +51,9 @@ public:
   using pointer = typename container_type::const_pointer;
   using const_pointer = pointer;
   using iterator = typename container_type::const_iterator;
-  using reverse_iterator = typename container_type::const_reverse_iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
   using const_iterator = iterator;
-  using const_reverse_iterator = reverse_iterator;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 public:
   /* constructors */
@@ -134,14 +135,14 @@ public:
 
   /* iterators */
   constexpr const_iterator begin() const { return keys_.begin(); }
-  constexpr const_iterator cbegin() const { return keys_.cbegin(); }
+  constexpr const_iterator cbegin() const { return keys_.begin(); }
   constexpr const_iterator end() const { return keys_.end(); }
-  constexpr const_iterator cend() const { return keys_.cend(); }
+  constexpr const_iterator cend() const { return keys_.end(); }
 
-  constexpr const_reverse_iterator rbegin() const { return keys_.rbegin(); }
-  constexpr const_reverse_iterator crbegin() const { return keys_.crbegin(); }
-  constexpr const_reverse_iterator rend() const { return keys_.rend(); }
-  constexpr const_reverse_iterator crend() const { return keys_.crend(); }
+  constexpr const_reverse_iterator rbegin() const { return const_reverse_iterator{keys_.end()}; }
+  constexpr const_reverse_iterator crbegin() const { return const_reverse_iterator{keys_.end()}; }
+  constexpr const_reverse_iterator rend() const { return const_reverse_iterator{keys_.begin()}; }
+  constexpr const_reverse_iterator crend() const { return const_reverse_iterator{keys_.begin()}; }
 
   /* comparison */
   constexpr bool operator==(set const& rhs) const { return bits::equal(begin(), end(), rhs.begin()); }

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -86,6 +86,10 @@ public:
     return size() < other.size();
   }
 
+  friend constexpr bool operator>(const basic_string& lhs, const basic_string& rhs) {
+    return rhs < lhs;
+  }
+
   constexpr const chr_t *data() const { return data_; }
   constexpr const chr_t *begin() const { return data(); }
   constexpr const chr_t *end() const { return data() + size(); }

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -52,7 +52,7 @@ template <class Key, class Value, std::size_t N, typename Hash = anna<Key>,
 class unordered_map : private KeyEqual {
   static constexpr std::size_t storage_size =
       bits::next_highest_power_of_two(N) * (N < 32 ? 2 : 1); // size adjustment to prevent high collision rate for small sets
-  using container_type = bits::carray<std::pair<Key, Value>, N>;
+  using container_type = bits::carray<std::pair<const Key, Value>, N>;
   using tables_type = bits::pmh_tables<storage_size, Hash>;
 
   container_type items_;

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -199,7 +199,7 @@ private:
   static inline constexpr auto find_impl(This&& self, KeyType const &key, Hasher const &hash, Equal const &equal) {
     auto const pos = self.tables_.lookup(key, hash);
     auto it = self.items_.begin() + pos;
-    if (equal(it->first, key))
+    if (it != self.items_.end() && equal(it->first, key))
       return it;
     else
       return self.items_.end();

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -102,8 +102,8 @@ public:
   constexpr iterator end() { return items_.end(); }
   constexpr const_iterator begin() const { return items_.begin(); }
   constexpr const_iterator end() const { return items_.end(); }
-  constexpr const_iterator cbegin() const { return items_.cbegin(); }
-  constexpr const_iterator cend() const { return items_.cend(); }
+  constexpr const_iterator cbegin() const { return items_.begin(); }
+  constexpr const_iterator cend() const { return items_.end(); }
 
   /* capacity */
   constexpr bool empty() const { return !N; }

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -116,7 +116,7 @@ public:
   constexpr const_iterator find(KeyType const &key, Hasher const &hash, Equal const &equal) const {
     auto const pos = tables_.lookup(key, hash);
     auto it = keys_.begin() + pos;
-    if (equal(*it, key))
+    if (it != keys_.end() && equal(*it, key))
       return it;
     else
       return keys_.end();

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -67,7 +67,7 @@ public:
   using reference = const_reference;
   using const_pointer = typename container_type::const_pointer;
   using pointer = const_pointer;
-  using const_iterator = const_pointer;
+  using const_iterator = typename container_type::const_iterator;
   using iterator = const_iterator;
 
 public:

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -93,8 +93,8 @@ public:
   /* iterators */
   constexpr const_iterator begin() const { return keys_.begin(); }
   constexpr const_iterator end() const { return keys_.end(); }
-  constexpr const_iterator cbegin() const { return keys_.cbegin(); }
-  constexpr const_iterator cend() const { return keys_.cend(); }
+  constexpr const_iterator cbegin() const { return keys_.begin(); }
+  constexpr const_iterator cend() const { return keys_.end(); }
 
   /* capacity */
   constexpr bool empty() const { return !N; }

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -105,8 +105,7 @@ public:
   /* lookup */
   template <class KeyType, class Hasher, class Equal>
   constexpr std::size_t count(KeyType const &key, Hasher const &hash, Equal const &equal) const {
-    auto const & k = lookup(key, hash);
-    return equal(k, key);
+    return find(key, hash, equal) != end();
   }
   template <class KeyType>
   constexpr std::size_t count(KeyType const &key) const {
@@ -115,9 +114,10 @@ public:
 
   template <class KeyType, class Hasher, class Equal>
   constexpr const_iterator find(KeyType const &key, Hasher const &hash, Equal const &equal) const {
-    auto const &k = lookup(key, hash);
-    if (equal(k, key))
-      return &k;
+    auto const pos = tables_.lookup(key, hash);
+    auto it = keys_.begin() + pos;
+    if (equal(*it, key))
+      return it;
     else
       return keys_.end();
   }
@@ -134,9 +134,9 @@ public:
   template <class KeyType, class Hasher, class Equal>
   constexpr std::pair<const_iterator, const_iterator> equal_range(
           KeyType const &key, Hasher const &hash, Equal const &equal) const {
-    auto const &k = lookup(key, hash);
-    if (equal(k, key))
-      return {&k, &k + 1};
+    auto const it = find(key, hash, equal);
+    if (it != end())
+      return {it, it + 1};
     else
       return {keys_.end(), keys_.end()};
   }
@@ -152,12 +152,6 @@ public:
   /* observers*/
   constexpr const hasher& hash_function() const { return tables_.hash_; }
   constexpr const key_equal& key_eq() const { return equal_; }
-
-private:
-  template <class KeyType, class Hasher>
-  constexpr auto const &lookup(KeyType const &key, Hasher const &hash) const {
-    return keys_[tables_.lookup(key, hash)];
-  }
 };
 
 template <typename T, std::size_t N>

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -303,9 +303,9 @@ TEST_CASE("frozen::map <> frozen::make_map", "[map]") {
 }
 
 TEST_CASE("frozen::map constexpr", "[map]") {
-  constexpr frozen::map<int, unsigned, 2> ce = {{3,4}, {11,12}};
-  static_assert(*ce.begin() == std::pair<int, unsigned>{3,4}, "");
-  static_assert(*(ce.begin() + 1) == std::pair<int, unsigned>{11,12}, "");
+  constexpr frozen::map<int, unsigned, 2> ce = {{11,12}, {3,4}};
+  static_assert(*ce.begin() == std::pair<const int, unsigned>{3,4}, "");
+  static_assert(*(ce.begin() + 1) == std::pair<const int, unsigned>{11,12}, "");
   static_assert(ce.size() == 2, "");
   static_assert(ce.count(3), "");
   static_assert(!ce.count(0), "");

--- a/tests/test_unordered_map.cpp
+++ b/tests/test_unordered_map.cpp
@@ -226,24 +226,23 @@ TEST_CASE("Modifiable frozen::unordered_map", "[unordered_map]") {
   }
 }
 
+struct eq {
+  template<class StrTy>
+  constexpr auto operator()(const frozen::string &frozen, const StrTy &str) const {
+    return frozen == frozen::string{str.data(), str.size()};
+  }
+};
+
 TEST_CASE("frozen::unordered_map heterogeneous lookup", "[unordered_map]") {
   constexpr auto map = frozen::make_unordered_map<frozen::string, int>({{"one", 1}, {"two", 2}, {"three", 3}});
 
-  const auto eq = [](const frozen::string& frozen, const std::string& std) {
-      return frozen == frozen::string{std.data(), std.size()};
-  };
-
-  REQUIRE(map.find(std::string{"two"}, frozen::elsa<std::string>{}, eq)->second == 2);
+  REQUIRE(map.find(std::string{"two"}, frozen::elsa<std::string>{}, eq{})->second == 2);
 }
 
 TEST_CASE("frozen::unordered_map heterogeneous container", "[unordered_map]") {
-  const auto eq = [](const frozen::string& frozen, const auto& str) {
-    return frozen == frozen::string{str.data(), str.size()};
-  };
-
   constexpr auto map = frozen::make_unordered_map<frozen::string, int>(
           {{"one", 1}, {"two", 2}, {"three", 3}},
-          frozen::elsa<>{}, eq);
+          frozen::elsa<>{}, eq{});
 
   REQUIRE(map.find(std::string{"two"})->second == 2);
   REQUIRE(map.find(frozen::string{"two"})->second == 2);

--- a/tests/test_unordered_set.cpp
+++ b/tests/test_unordered_set.cpp
@@ -173,24 +173,20 @@ TEST_CASE("frozen::unordered_set deduction guide", "[unordered_set]") {
 
 #endif // FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
 
+struct eq {
+  template<class StrTy>
+  constexpr auto operator()(const frozen::string &frozen, const StrTy &str) const {
+    return frozen == frozen::string{str.data(), str.size()};
+  }
+};
+
 TEST_CASE("frozen::unordered_set heterogeneous lookup", "[unordered_set]") {
   using namespace frozen::string_literals;
 
   constexpr frozen::unordered_set<frozen::string, 3> set{"one"_s, "two"_s, "three"_s};
 
-  const auto eq = [](const frozen::string& frozen, const std::string& std) {
-    return frozen == frozen::string{std.data(), std.size()};
-  };
-
-  REQUIRE(set.find(std::string{"two"}, frozen::elsa<std::string>{}, eq) != set.end());
+  REQUIRE(set.find(std::string{"two"}, frozen::elsa<std::string>{}, eq{}) != set.end());
 }
-
-struct eq {
-  template<class StrTy>
-  auto operator()(const frozen::string &frozen, const StrTy &str) const {
-    return frozen == frozen::string{str.data(), str.size()};
-  }
-};
 
 TEST_CASE("frozen::unordered_set heterogeneous container", "[unordered_set]") {
   using namespace frozen::string_literals;


### PR DESCRIPTION
This is a set of fixes and minor refactors of issues that I encountered while trying to get this library to produce zero load-time relocations when compiling a container storing strings with `-fPIC`.

I thought it better to extract these to this separate PR, as they're useful regardless, before creating a massive PR for that.

FYI: I'm not fully happy yet with my changes for zero-reloc string containers so won't be creating an immediate follow-up PR for that just yet. But if you want to have a look at that, I'm keeping those changes in my [feat/zero-reloc-string-containers](https://github.com/muggenhor/frozen/compare/fixes...muggenhor:frozen:feat/zero-reloc-string-containers) branch.