### PR TITLE
Fixing "'macro' is not defined" warning, when using clang-tidy

### DIFF
--- a/include/frozen/bits/defines.h
+++ b/include/frozen/bits/defines.h
@@ -55,11 +55,11 @@
   #define FROZEN_LETITGO_HAS_CHAR8T
 #endif
 
-#if __cpp_deduction_guides >= 201703L
+#if defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703L
   #define FROZEN_LETITGO_HAS_DEDUCTION_GUIDES
 #endif
 
-#if __cpp_lib_constexpr_string >= 201907L
+#if defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L
   #define FROZEN_LETITGO_HAS_CONSTEXPR_STRING
 #endif
 


### PR DESCRIPTION
Using clang-tidy with frozen, shows following warning:
```cpp
/path/to/frozen-git/include/frozen/bits/defines.h:62:5: warning: '__cpp_lib_constexpr_string' is not defined, evaluates to 0 [clang-diagnostic-undef]
   62 | #if __cpp_lib_constexpr_string >= 201907L
      |     ^
```

This commit checks if the macro `__cpp_lib_constexpr_string` is defined before it compares the value.
The same is done with the macro `__cpp_deduction_guides`.

Compilers:
gcc 14.1.1 20240522
clang 17.0.6
