### PR TITLE
add operator to convert frozen::string to std::string view (with c++17 and more)

### DIFF
--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -59,6 +59,7 @@ public:
   constexpr basic_string(const basic_string &) noexcept = default;
   constexpr basic_string &operator=(const basic_string &) noexcept = default;
 
+  constexpr std::size_t length() const { return size_; }
   constexpr std::size_t size() const { return size_; }
 
   constexpr chr_t operator[](std::size_t i) const { return data_[i]; }

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -54,6 +54,17 @@ public:
 #ifdef FROZEN_LETITGO_HAS_STRING_VIEW
   constexpr basic_string(std::basic_string_view<chr_t> data)
       : data_(data.data()), size_(data.size()) {}
+
+  constexpr operator std::basic_string_view<chr_t>() const { return std::basic_string_view<chr_t>(data_, size_); }
+
+  constexpr bool operator==(std::basic_string_view<chr_t> other) const {
+    if (size_ != other.size())
+      return false;
+    for (std::size_t i = 0; i < size_; ++i)
+      if (data_[i] != other.data()[i])
+        return false;
+    return true;
+  }
 #endif
 
   constexpr basic_string(const basic_string &) noexcept = default;

--- a/include/frozen/string.h
+++ b/include/frozen/string.h
@@ -51,22 +51,6 @@ public:
   constexpr basic_string(chr_t const *data, std::size_t size)
       : data_(data), size_(size) {}
 
-#ifdef FROZEN_LETITGO_HAS_STRING_VIEW
-  constexpr basic_string(std::basic_string_view<chr_t> data)
-      : data_(data.data()), size_(data.size()) {}
-
-  constexpr operator std::basic_string_view<chr_t>() const { return std::basic_string_view<chr_t>(data_, size_); }
-
-  constexpr bool operator==(std::basic_string_view<chr_t> other) const {
-    if (size_ != other.size())
-      return false;
-    for (std::size_t i = 0; i < size_; ++i)
-      if (data_[i] != other.data()[i])
-        return false;
-    return true;
-  }
-#endif
-
   constexpr basic_string(const basic_string &) noexcept = default;
   constexpr basic_string &operator=(const basic_string &) noexcept = default;
 
@@ -74,6 +58,32 @@ public:
   constexpr std::size_t size() const { return size_; }
 
   constexpr chr_t operator[](std::size_t i) const { return data_[i]; }
+
+#ifdef FROZEN_LETITGO_HAS_STRING_VIEW
+  constexpr basic_string(std::basic_string_view<chr_t> data)
+      : data_(data.data()), size_(data.size()) {}
+
+  constexpr operator std::basic_string_view<chr_t>() const {
+    return std::basic_string_view<chr_t>(data_, size_);
+  }
+
+  constexpr bool operator==(std::basic_string_view<chr_t> other) const {
+    return (std::basic_string_view<chr_t>(data_, size_) == other);
+  }
+
+  constexpr bool operator<(const std::basic_string_view<chr_t> &other) const {
+    return (std::basic_string_view<chr_t>(data_, size_) < other);
+  }
+
+  constexpr bool operator==(basic_string other) const {
+    return (std::basic_string_view<chr_t>(data_, size_) == std::basic_string_view<chr_t>(other.data_, other.size_));
+  }
+
+  constexpr bool operator<(const basic_string &other) const {
+    return (std::basic_string_view<chr_t>(data_, size_) < std::basic_string_view<chr_t>(other.data_, other.size_));
+  }
+
+#else
 
   constexpr bool operator==(basic_string other) const {
     if (size_ != other.size_)
@@ -97,6 +107,8 @@ public:
     }
     return size() < other.size();
   }
+
+#endif
 
   friend constexpr bool operator>(const basic_string& lhs, const basic_string& rhs) {
     return rhs < lhs;


### PR DESCRIPTION
With this operator, it is more easy to convert
```
const std::unordered_map<std::string_view, std::string_view> network_map({
```
to
```
frozen::unordered_map<frozen::string, frozen::string, 1047>network_map = {
```