### PR TITLE
Detect bad initialization when not under -DNDEBUG

### DIFF
--- a/include/frozen/bits/basic_types.h
+++ b/include/frozen/bits/basic_types.h
@@ -99,7 +99,7 @@ class carray {
 
   static constexpr void check_initializer(std::initializer_list<T> init) {
     (void)init;
-    constexpr_assert(init.size() >= N, "Cannot initialize a carray with an smaller initializer list");
+    constexpr_assert(init.size() == N, "Cannot initialize a carray with an initializer list of different size.");
   }
 
 public:

--- a/include/frozen/unordered_map.h
+++ b/include/frozen/unordered_map.h
@@ -83,7 +83,7 @@ public:
       , items_{items}
       , tables_{
             bits::make_pmh_tables<storage_size>(
-                items_, hash, bits::GetKey{}, default_prg_t{})} {}
+                items_, hash, equal, bits::GetKey{}, default_prg_t{})} {}
   explicit constexpr unordered_map(container_type items)
       : unordered_map{items, Hash{}, KeyEqual{}} {
       }

--- a/include/frozen/unordered_set.h
+++ b/include/frozen/unordered_set.h
@@ -77,7 +77,7 @@ public:
       : KeyEqual{equal}
       , keys_{keys}
       , tables_{bits::make_pmh_tables<storage_size>(
-            keys_, hash, bits::Get{}, default_prg_t{})} {}
+            keys_, hash, equal, bits::Get{}, default_prg_t{})} {}
   explicit constexpr unordered_set(container_type keys)
       : unordered_set{keys, Hash{}, KeyEqual{}} {}
 


### PR DESCRIPTION
* initialization list too short
* initialization list too long
* duplicate keys for unordered_set/unordered_map