### PR TITLE
Removed prefix from code so it can be copied and executed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,10 +43,10 @@ Just copy the ``include/frozen`` directory somewhere and points to it using the 
 
 .. code:: sh
 
-    > mkdir build
-    > cd build
-    > cmake -D CMAKE_BUILD_TYPE=Release ..
-    > make install
+    mkdir build
+    cd build
+    cmake -D CMAKE_BUILD_TYPE=Release ..
+    make install
 
 
 Installation via CMake populates configuration files into the ``/usr/local/share``
@@ -197,45 +197,45 @@ Using hand-written Makefiles crafted with love and care:
 
 .. code:: sh
 
-    > # running tests
-    > make -C tests check
-    > # running benchmarks
-    > make -C benchmarks GOOGLE_BENCHMARK_PREFIX=<GOOGLE-BENCHMARK_INSTALL_DIR>
+    # running tests
+    make -C tests check
+    # running benchmarks
+    make -C benchmarks GOOGLE_BENCHMARK_PREFIX=<GOOGLE-BENCHMARK_INSTALL_DIR>
 
 Using CMake to generate a static configuration build system:
 
 .. code:: sh
 
-    > mkdir build
-    > cd build
-    > cmake -D CMAKE_BUILD_TYPE=Release \
+    mkdir build
+    cd build
+    cmake -D CMAKE_BUILD_TYPE=Release \
             -D frozen.benchmark=ON \
 	    -G <"Unix Makefiles" or "Ninja"> ..
-    > # building the tests and benchmarks...
-    > make                               # ... with make
-    > ninja                              # ... with ninja
-    > cmake --build .                    # ... with cmake
-    > # running the tests...
-    > make test                          # ... with make
-    > ninja test                         # ... with ninja
-    > cmake --build . --target test      # ... with cmake
-    > ctest                              # ... with ctest
-    > # running the benchmarks...
-    > make benchmark                     # ... with make
-    > ninja benchmark                    # ... with ninja
-    > cmake --build . --target benchmark # ... with cmake
+    # building the tests and benchmarks...
+    make                               # ... with make
+    ninja                              # ... with ninja
+    cmake --build .                    # ... with cmake
+    # running the tests...
+    make test                          # ... with make
+    ninja test                         # ... with ninja
+    cmake --build . --target test      # ... with cmake
+    ctest                              # ... with ctest
+    # running the benchmarks...
+    make benchmark                     # ... with make
+    ninja benchmark                    # ... with ninja
+    cmake --build . --target benchmark # ... with cmake
 
 Using CMake to generate an IDE build system with test and benchmark targets
 
 .. code:: sh
 
-    > mkdir build
-    > cd build
-    > cmake -D frozen.benchmark=ON -G <"Xcode" or "Visual Studio 15 2017"> ..
-    > # using cmake to drive the IDE build, test, and benchmark
-    > cmake --build . --config Release
-    > cmake --build . --target test
-    > cmake --build . --target benchmark
+    mkdir build
+    cd build
+    cmake -D frozen.benchmark=ON -G <"Xcode" or "Visual Studio 15 2017"> ..
+    # using cmake to drive the IDE build, test, and benchmark
+    cmake --build . --config Release
+    cmake --build . --target test
+    cmake --build . --target benchmark
 
 
 Credits


### PR DESCRIPTION
If there are > in front of every line the terminal will complain. This is not a problem if you copy line by line and can just exclude them. But modern terminals allow pasting multiple lines of instructions and execute them after each other. The > prevent simply copying all lines and pasting them like with the copy code button