### PR TITLE
Fix compile error with std::pair as map key

### DIFF
--- a/include/frozen/bits/mpl.h
+++ b/include/frozen/bits/mpl.h
@@ -49,6 +49,15 @@ struct remove_cv<carray<T, N>> {
 template <typename T>
 using remove_cv_t = typename remove_cv<T>::type;
 
+template <typename F, typename T, typename U, typename = void>
+struct is_comparator : std::false_type {};
+
+template <typename F, typename T, typename U>
+struct is_comparator<F, T, U, std::enable_if_t<std::is_convertible<
+  decltype(std::declval<F>()(std::declval<T>(), std::declval<U>())),
+  bool
+>::value>> : std::true_type {};
+
 } // namespace bits
 
 } // namespace frozen

--- a/include/frozen/bits/mpl.h
+++ b/include/frozen/bits/mpl.h
@@ -49,15 +49,6 @@ struct remove_cv<carray<T, N>> {
 template <typename T>
 using remove_cv_t = typename remove_cv<T>::type;
 
-template <typename F, typename T, typename U, typename = void>
-struct is_comparator : std::false_type {};
-
-template <typename F, typename T, typename U>
-struct is_comparator<F, T, U, std::enable_if_t<std::is_convertible<
-  decltype(std::declval<F>()(std::declval<T>(), std::declval<U>())),
-  bool
->::value>> : std::true_type {};
-
 } // namespace bits
 
 } // namespace frozen

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -45,19 +45,19 @@ public:
   constexpr CompareKey(Comparator const &comparator)
       : Comparator(comparator) {}
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
+  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
   constexpr int operator()(std::pair<Key1, Value> const &self,
                            std::pair<Key2, Value> const &other) const {
     return key_comp()(std::get<0>(self), std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
+  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
   constexpr int operator()(Key1 const &self_key,
                            std::pair<Key2, Value> const &other) const {
     return key_comp()(self_key, std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
+  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
   constexpr int operator()(std::pair<Key1, Value> const &self,
                            Key2 const &other_key) const {
     return key_comp()(std::get<0>(self), other_key);

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -45,19 +45,19 @@ public:
   constexpr CompareKey(Comparator const &comparator)
       : Comparator(comparator) {}
 
-  template <class Key1, class Key2, class Value>
+  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
   constexpr int operator()(std::pair<Key1, Value> const &self,
                            std::pair<Key2, Value> const &other) const {
     return key_comp()(std::get<0>(self), std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value>
+  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
   constexpr int operator()(Key1 const &self_key,
                            std::pair<Key2, Value> const &other) const {
     return key_comp()(self_key, std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value>
+  template <class Key1, class Key2, class Value, std::enable_if_t<std::is_same<bits::remove_cv_t<Key1>, bits::remove_cv_t<Key2>>::value, int> = 0>
   constexpr int operator()(std::pair<Key1, Value> const &self,
                            Key2 const &other_key) const {
     return key_comp()(std::get<0>(self), other_key);

--- a/include/frozen/map.h
+++ b/include/frozen/map.h
@@ -45,26 +45,26 @@ public:
   constexpr CompareKey(Comparator const &comparator)
       : Comparator(comparator) {}
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
-  constexpr int operator()(std::pair<Key1, Value> const &self,
-                           std::pair<Key2, Value> const &other) const {
+  template <class Key1, class Key2, class Value>
+  constexpr auto operator()(std::pair<Key1, Value> const &self,
+                           std::pair<Key2, Value> const &other) const -> decltype(key_comp()(std::get<0>(self), std::get<0>(other))) {
     return key_comp()(std::get<0>(self), std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
-  constexpr int operator()(Key1 const &self_key,
-                           std::pair<Key2, Value> const &other) const {
+  template <class Key1, class Key2, class Value>
+  constexpr auto operator()(Key1 const &self_key,
+                           std::pair<Key2, Value> const &other) const -> decltype(key_comp()(self_key, std::get<0>(other))) {
     return key_comp()(self_key, std::get<0>(other));
   }
 
-  template <class Key1, class Key2, class Value, std::enable_if_t<bits::is_comparator<Comparator, Key1, Key2>::value, int> = 0>
-  constexpr int operator()(std::pair<Key1, Value> const &self,
-                           Key2 const &other_key) const {
+  template <class Key1, class Key2, class Value>
+  constexpr auto operator()(std::pair<Key1, Value> const &self,
+                           Key2 const &other_key) const -> decltype(key_comp()(std::get<0>(self), other_key)) {
     return key_comp()(std::get<0>(self), other_key);
   }
 
   template <class Key1, class Key2>
-  constexpr int operator()(Key1 const &self_key, Key2 const &other_key) const {
+  constexpr auto operator()(Key1 const &self_key, Key2 const &other_key) const -> decltype(key_comp()(self_key, other_key)) {
     return key_comp()(self_key, other_key);
   }
 };

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -498,3 +498,13 @@ TEST_CASE("frozen::map <> frozen::make_map transparent", "[map]") {
     REQUIRE(frozen_empty_map3.begin() == frozen_empty_map3.end());
   }
 }
+
+TEST_CASE("frozen::map constexpr std::pair key", "[map]") {
+  constexpr frozen::map<std::pair<int, int>, bool, 2> ce1 = {
+      {{1, 2}, true}, {{3, 4}, false}};
+  static_assert(ce1.find(std::pair<int, int>{1, 3}) == ce1.end(), "");
+
+  constexpr frozen::map<std::pair<int, int>, int, 2> ce2 = {
+      {{1, 2}, 5}, {{3, 4}, 6}};
+  static_assert(ce2.at({3, 4}) == 6, "");
+}


### PR DESCRIPTION
Overload resolution chooses the wrong comparison function when using `std::pair` as a map key.

Note that given `frozen::map<std::pair<K1, K2>, V, N>`, there are different errors if `K2` and `V` are the same of different types.  Both cases are handled by this PR.

Fixes #188