### PR TITLE
Slightly improve duplicate key checking

### DIFF
--- a/include/frozen/bits/constexpr_assert.h
+++ b/include/frozen/bits/constexpr_assert.h
@@ -24,16 +24,11 @@
 #define FROZEN_LETITGO_CONSTEXPR_ASSERT_H
 
 #include <cassert>
+#include <utility>
 
-#ifdef _MSC_VER
+inline void constexpr_assert_failed() {}
 
-// FIXME: find a way to implement that correctly for msvc
-#define constexpr_assert(cond, msg)
-#else
-
-#define constexpr_assert(cond, msg)\
-    assert(cond && msg)
-#endif
+#define constexpr_assert(cond, msg) ((void)((cond) ? 0 : (constexpr_assert_failed(), 0)))
 
 #endif
 

--- a/include/frozen/bits/pmh.h
+++ b/include/frozen/bits/pmh.h
@@ -194,12 +194,10 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const carray<Item, N> &
   // Step 1: Place all of the keys into buckets
   auto step_one = make_pmh_buckets<M>(items, hash, key, prg);
 
-#ifndef NDEBUG
   // Step 1.5: Detect redundant keys.
   for(auto const& bucket : step_one.buckets)
     for(std::size_t i = 1; i < bucket.size(); ++i)
-      constexpr_assert(!equal(key(items[0]), key(items[i])), "unique keys");
-#endif
+      constexpr_assert(!equal(key(items[0]), key(items[i])), "structure keys should be unique");
 
   // Step 2: Sort the buckets to process the ones with the most items first.
   auto buckets = step_one.get_sorted_buckets();


### PR DESCRIPTION
There's no use in relying on `assert` for compile-time assert in our context.

Also always perform the check, even under -DNDEBUG

Fix #175